### PR TITLE
Fix race condition in AnarchySubject caching

### DIFF
--- a/anarchy-runner/files/ansible-runner/project/callback_plugins/anarchy.py
+++ b/anarchy-runner/files/ansible-runner/project/callback_plugins/anarchy.py
@@ -36,6 +36,16 @@ DOCUMENTATION = '''
 def current_time():
     return '%sZ' % datetime.datetime.utcnow().isoformat()
 
+def munge_result(result):
+    """Return cleaned up and pruned version of result dict"""
+    # Clean up result for record
+    ret = result._result.copy()
+    if 'stdout' and 'stdout_lines' in ret:
+        del ret['stdout_lines']
+    if 'stderr' and 'stderr_lines' in ret:
+        del ret['stdout_lines']
+    return ret
+
 class CallbackModule(CallbackModule_default):
     CALLBACK_VERSION = 2.0
     CALLBACK_TYPE = 'stdout'
@@ -87,8 +97,7 @@ class CallbackModule(CallbackModule_default):
         else:
             items = self.anarchy_task_hosts[host]['items']
         item = extra.copy()
-
-        item['result'] = result._result.copy()
+        item['result'] = munge_result(result)
         items.append(item)
 
     def anarchy_record_stats(self, stats):

--- a/operator/files/anarchyrun.py
+++ b/operator/files/anarchyrun.py
@@ -28,7 +28,7 @@ class AnarchyRun(object):
             return
         elif runner_value == 'failed':
             anarchy_subject.anarchy_run_update(anarchy_run, runtime)
-            last_attempt = anarchy_run.run_post_datetime()
+            last_attempt = anarchy_run.run_post_datetime
             if last_attempt:
                 retry_delay = timedelta(seconds=5 * 2**anarchy_run.failures)
                 if retry_delay > timedelta(hours=1):


### PR DESCRIPTION
This PR fixes a bug in AnarchySubject caching that was preventing runs from executing on start-up.
Also included is fixes to reduce the size of an AnarchyRun resource when it fails repeatedly. Prior to this fix the AnarchyRun resource would grow unbounded until it was too large to be handled by etcd.