### PR TITLE
Add awscli to anarchy-runner

### DIFF
--- a/anarchy-runner/files/requirements.txt
+++ b/anarchy-runner/files/requirements.txt
@@ -1,6 +1,7 @@
 ansible
 ansible-runner
 awscli
+boto3
 jmespath
 jsonpatch
 kubernetes

--- a/anarchy-runner/files/requirements.txt
+++ b/anarchy-runner/files/requirements.txt
@@ -1,7 +1,7 @@
 ansible
 ansible-runner
+awscli
 jmespath
 jsonpatch
 kubernetes
 openshift
-awscli

--- a/anarchy-runner/files/requirements.txt
+++ b/anarchy-runner/files/requirements.txt
@@ -4,3 +4,4 @@ jmespath
 jsonpatch
 kubernetes
 openshift
+awscli


### PR DESCRIPTION
In order to be able to get sandboxes and release them from the pool of AWS
sandboxes, add the AWS CLI to the anarchy-runner image.