### PR TITLE
Complete helm chart for installing the operator

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -103,18 +103,13 @@ git clone https://github.com/redhat-cop/anarchy.git
 cd anarchy
 ----
 
-. Create a namespace in which to deploy the Anarchy operator
-+
-----
-kubectl create namespace anarchy-operator
-----
-
 . Install with Helm
 +
 ----
-helm install --namespace anarchy-operator anarchy helm/
+helm template helm | oc apply -f -
 ----
 +
+Support for Openshift Route is included in the Helm chart, but is disabled by default (use `--set openshift.enabled=true`)
 Support for Kubernetes ingress is included in the Helm chart, but is currently untested.
 
 == Building the Anarchy Operator and Runner

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: anarchy
 description: Anarchy Operator
 type: application
-version: 0.4.1
-appVersion: 0.4.1
+version: 0.1.0
+appVersion: v0.4.3

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -43,3 +43,48 @@ Create the name of the service account to use
 {{      default "default" .Values.serviceAccount.name }}
 {{-   end -}}
 {{- end -}}
+
+{{/*
+Create the name of the namespace to use
+*/}}
+{{- define "anarchy.namespaceName" -}}
+{{- if .Values.namespace.create -}}
+    {{ default (include "anarchy.name" .) .Values.namespace.name }}
+{{- else -}}
+    {{ default "default" .Values.namespace.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the operator domain to use
+*/}}
+{{- define "anarchy.operatorDomain" -}}
+{{- if and .Values.operator_domain.generate .Values.operator_domain.name -}}
+    {{ .Values.operator_domain.name }}
+{{- else -}}
+    {{ printf "%s.gpte.redhat.com" (default (include "anarchy.name" .) .Chart.Name) }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Define the operator image to deploy
+*/}}
+{{- define "anarchy.operator.image" -}}
+{{- printf "%s:%s" .Values.image.anarchyOperator.repository (default .Chart.AppVersion .Values.image.anarchyOperator.tagOverride) -}}
+{{- end -}}
+
+{{/*
+Define the runner image to deploy
+*/}}
+{{- define "anarchy.runner.image" -}}
+{{- printf "%s:%s" .Values.image.anarchyRunner.repository (default .Chart.AppVersion .Values.image.anarchyRunner.tagOverride) -}}
+{{- end -}}
+
+{{/*
+Define the anarchy FQDN
+*/}}
+{{- define "anarchy.hostname" -}}
+{{- if .Values.openshift.enabled -}}
+{{- default (printf "%s.%s" (include "anarchy.name" .) (regexReplaceAll "console." (lookup "route.openshift.io/v1" "Route" "openshift-console" "console").spec.host "${1}")) .Values.openshift.route.host -}}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/anarchyrunner.yaml
+++ b/helm/templates/anarchyrunner.yaml
@@ -1,0 +1,20 @@
+apiVersion: anarchy.gpte.redhat.com/v1
+kind: AnarchyRunner
+metadata:
+  name: default
+spec:
+  ansibleGalaxyRoles: []
+  minReplicas: 1
+  maxReplicas: 9
+  preTasks: []
+  postTasks: []
+  resources:
+    limits:
+      cpu: "1"
+      memory: 256Mi
+    requests:
+      cpu: 500m
+      memory: 256Mi
+  token: {{ randAlphaNum 16 }}
+  vars: {}
+  varSecrets: []

--- a/helm/templates/crds.yaml
+++ b/helm/templates/crds.yaml
@@ -1,0 +1,81 @@
+{{- if .Values.crds.create -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: anarchyactions.{{ include "anarchy.operatorDomain" . }}
+spec:
+  group: {{ include "anarchy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: anarchyactions
+    singular: anarchyaction
+    kind: AnarchyAction
+    shortNames: []
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: anarchygovernors.{{ include "anarchy.operatorDomain" . }}
+spec:
+  group: {{ include "anarchy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: anarchygovernors
+    singular: anarchygovernor
+    kind: AnarchyGovernor
+    shortNames: []
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: anarchyrunners.{{ include "anarchy.operatorDomain" . }}
+spec:
+  group: {{ include "anarchy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: anarchyrunners
+    singular: anarchyrunner
+    kind: AnarchyRunner
+    shortNames: []
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: anarchyruns.{{ include "anarchy.operatorDomain" . }}
+spec:
+  group: {{ include "anarchy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: anarchyruns
+    singular: anarchyrun
+    kind: AnarchyRun
+    shortNames: []
+  subresources:
+    status: {}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: anarchysubjects.{{ include "anarchy.operatorDomain" . }}
+spec:
+  group: {{ include "anarchy.operatorDomain" . }}
+  version: v1
+  scope: Namespaced
+  names:
+    plural: anarchysubjects
+    singular: anarchysubject
+    kind: AnarchySubject
+    shortNames: []
+  subresources:
+    status: {}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         imagePullPolicy: {{ .Values.image.anarchyOperator.pullPolicy }}
         {{- with .Values.image.anarchyOperator.livenessProbe }}
         livenessProbe:
-					{{- toYaml . | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
         {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "anarchy.name" . }}
+  namespace: {{ include "anarchy.namespaceName" . }}
   labels:
     {{- include "anarchy.labels" . | nindent 4 }}
 spec:
@@ -20,22 +21,31 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-      serviceAccountName: {{ include "anarchy.serviceAccountName" . }}
       containers:
       - name: manager
         env:
         - name: ANARCHY_SERVICE
           value: {{ include "anarchy.name" . }}
         - name: CALLBACK_BASE_URL
-          value: https://{{ .Values.anarchyHostname }}
+          value: https://{{ include "anarchy.hostname" . }}
         - name: RUNNER_IMAGE
-          value: {{ .Values.image.anarchyRunner.repository }}:v{{ .Chart.AppVersion }}
+          value: {{ include "anarchy.runner.image" . }}
         - name: RUNNER_IMAGE_PULL_POLICY
           value: {{ .Values.image.anarchyRunner.pullPolicy }}
-        image: {{ .Values.image.anarchyOperator.repository }}:v{{ .Chart.AppVersion }}
+        image: {{ include "anarchy.operator.image" . }}
         imagePullPolicy: {{ .Values.image.anarchyOperator.pullPolicy }}
+        {{- with .Values.image.anarchyOperator.livenessProbe }}
+        livenessProbe:
+					{{- toYaml . | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      restartPolicy: Always
+      securityContext: {}
+      serviceAccountName: {{ include "anarchy.serviceAccountName" . }}
+      terminationGracePeriodSeconds: 30
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/templates/namespace.yaml
+++ b/helm/templates/namespace.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.namespace.create -}}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ include "anarchy.namespaceName" . }}
+  labels:
+    {{- include "anarchy.labels" . | nindent 4 }}
+  annotations:
+    openshift-provision/action: create
+{{- end -}}

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -1,0 +1,108 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "anarchy.name" . }}
+  namespace: {{ include "anarchy.namespaceName" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "anarchy.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "anarchy.name" . }}
+  namespace: {{ include "anarchy.namespaceName" . }}
+{{- if .Values.crds.create }}
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: {{ include "anarchy.name" . }}
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - {{ include "anarchy.operatorDomain" . }}
+  resources:
+  - anarchygovernors
+  - anarchyrunners
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - {{ include "anarchy.operatorDomain" . }}
+  resources:
+  - anarchyactions
+  - anarchyactions/status
+  - anarchyrunners/status
+  - anarchyruns
+  - anarchyruns/status
+  - anarchysubjects
+  - anarchysubjects/status
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - deployments/rollback
+  - deployments/scale
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - secrets
+  - serviceaccounts
+  - services
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+---
+kind: ClusterRole
+apiVersion: v1
+metadata:
+  name: anarchy-operator-admin
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+- apiGroups:
+  - {{ include "anarchy.operatorDomain" . }}
+  resources:
+  - anarchygovernors
+  - anarchyrunners
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
+{{- end -}}

--- a/helm/templates/rbac.yaml
+++ b/helm/templates/rbac.yaml
@@ -13,8 +13,8 @@ subjects:
   namespace: {{ include "anarchy.namespaceName" . }}
 {{- if .Values.crds.create }}
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-apiVersion: v1
 metadata:
   name: {{ include "anarchy.name" . }}
   labels:
@@ -84,8 +84,8 @@ rules:
   - patch
   - update
 ---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
-apiVersion: v1
 metadata:
   name: anarchy-operator-admin
   labels:

--- a/helm/templates/route.yaml
+++ b/helm/templates/route.yaml
@@ -14,4 +14,7 @@ spec:
   to:
     kind: Service
     name: {{ $name }}
+    weight: 100
+status:
+  ingress: []
 {{- end }}

--- a/helm/templates/route.yaml
+++ b/helm/templates/route.yaml
@@ -4,8 +4,9 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: {{ $name }}
+  namespace: {{ include "anarchy.namespaceName" . }}
 spec:
-  host: {{ .Values.openshift.route.host }}
+  host: {{ include "anarchy.hostname" . }}
   port:
     targetPort: api
   tls:

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -2,14 +2,15 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "anarchy.name" . }}
+  namespace: {{ include "anarchy.namespaceName" . }}
   labels:
     {{- include "anarchy.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
+  {{- with .Values.service.ports }}
   ports:
-    - port: {{ .Values.service.port }}
-      targetPort: http
-      protocol: TCP
-      name: http
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   selector:
     {{- include "anarchy.selectorLabels" . | nindent 4 }}
+  sessionAffinity: None

--- a/helm/templates/serviceaccount.yaml
+++ b/helm/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "anarchy.serviceAccountName" . }}
+  namespace: {{ include "anarchy.namespaceName" . }}
   labels:
-{{ include "anarchy.labels" . | nindent 4 }}
+{{- include "anarchy.labels" . | nindent 4 }}
 {{- end -}}

--- a/helm/templates/tests/test-connection.yaml
+++ b/helm/templates/tests/test-connection.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "anarchy.name" . }}-test-connection"
+  namespace: {{ include "anarchy.namespaceName" . }}
+  labels:
+    {{- include "anarchy.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "anarchy.name" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,33 +1,67 @@
 ---
+namespace:
+  # Specifies whether a namespace should be created
+  create: true
+  # The name of the namespace to use.
+  # If not set and create is true, a name is generated using the name template
+  name:
+
+# Installing CustomResourceDefinitions requires elevated privileges (typically cluster-admin)
+crds:
+  create: true
+
+operator_domain:
+  # Specifies whether the operator domain should be generatedi (default: poolboy.gpte.redhat.com)
+  generate: true
+  # The name of the operator domain to use
+  # If not set and create is true, a name is generated using the operatorDomain template
+  name:
+
+replicaCount: 1
+
 image:
   anarchyOperator:
-    repository: quay.io/gpte-devops-automation/anarchy-operator
+    repository: quay.io/redhat-cop/anarchy
     pullPolicy: IfNotPresent
+    tagOverride: ""
+    livenessProbe:
+      httpGet:
+        path: /healthz
+        port: 8080
   anarchyRunner:
-    repository: quay.io/gpte-devops-automation/anarchy-operator
+    repository: quay.io/redhat-cop/anarchy-runner
     pullPolicy: IfNotPresent
-
-namespace: anarchy-operator
+    tagOverride: ""
 
 imagePullSecrets: []
-nameOverride: ""
+nameOverride: anarchy-operator
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
+  # Annotations to add to the service account
+  annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the name template
   name:
 
 service:
   type: ClusterIP
-  port: 80
-
+  port: 8000
+  ports:
+  - name: api
+    port: 5000
+    protocol: TCP
+    targetPort: 5000
+  - name: metrics
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
 
 openshift:
   enabled: false
   route:
-    host: anarchy.apps.example.com
+    host:
 
 ingress:
   enabled: false


### PR DESCRIPTION
The Helm chart now uses the `appVersion` in the `Chart.yaml` as the default image(s) tag. This can be overridden in the `value.yaml` file.
I'm also wondering if we now should remove `{install,deploy}-template.yaml` and complete the move to Helm?