### PR TITLE
Add missing uid type in anarchyaction CRD validation

### DIFF
--- a/helm/crds/anarchyactions.yaml
+++ b/helm/crds/anarchyactions.yaml
@@ -135,5 +135,6 @@ spec:
                   namespace:
                     type: string
                   uid:
+                    type: string
               runScheduled:
                 type: string


### PR DESCRIPTION
There's a missing type in one of the validation properties
```
❯ oc apply -f helm/crds/ --dry-run=client --validate
customresourcedefinition.apiextensions.k8s.io/anarchygovernors.anarchy.gpte.redhat.com configured (dry run)
customresourcedefinition.apiextensions.k8s.io/anarchyrunners.anarchy.gpte.redhat.com configured (dry run)
customresourcedefinition.apiextensions.k8s.io/anarchyruns.anarchy.gpte.redhat.com configured (dry run)
customresourcedefinition.apiextensions.k8s.io/anarchysubjects.anarchy.gpte.redhat.com configured (dry run)
error: error validating "helm/crds/anarchyactions.yaml": error validating data: unknown object type "nil" in CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema.properties.status.properties.runRef.properties.uid; if you choose to ignore these errors, turn validation off with --validate=false
```

```
❯ oc version
Client Version: 4.5.0
Server Version: 4.5.4
Kubernetes Version: v1.18.3+012b3ec
```