### PR TITLE
Add exclusive action execution

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -21,12 +21,14 @@ chmod ug=rw,o= \
 
 mkdir -p \
   /opt/app-root/anarchy-runner/.ansible \
+  /opt/app-root/anarchy-runner/output \
   /opt/app-root/anarchy-runner/ansible-runner/artifacts \
   /opt/app-root/anarchy-runner/ansible-runner/env \
   /opt/app-root/anarchy-runner/ansible-runner/inventory/group_vars/all
 
 chmod ug=rwx,o= \
   /opt/app-root/anarchy-runner/.ansible \
+  /opt/app-root/anarchy-runner/output \
   /opt/app-root/anarchy-runner/ansible-runner/artifacts \
   /opt/app-root/anarchy-runner/ansible-runner/env \
   /opt/app-root/anarchy-runner/ansible-runner/inventory/group_vars/all

--- a/anarchy-runner/ansible-runner/ansible.cfg
+++ b/anarchy-runner/ansible-runner/ansible.cfg
@@ -2,4 +2,4 @@
 # Use anarchy-runner tmp directory
 local_tmp = /opt/app-root/anarchy-runner/.ansible/tmp
 remote_tmp = /opt/app-root/anarchy-runner/.ansible/tmp
-anarchy_result_file = /opt/app-root/anarchy-runner/.ansible/anarchy-result.yaml
+anarchy_output_dir = /opt/app-root/anarchy-runner/output

--- a/anarchy-runner/ansible-runner/project/action_plugins/anarchy_continue_action.py
+++ b/anarchy-runner/ansible-runner/project/action_plugins/anarchy_continue_action.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2019, Johnathan Kupferer <jkupfere@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import os
+import re
+import yaml
+
+from ansible.plugins.action import ActionBase
+from datetime import datetime, timedelta
+
+datetime_re = re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
+
+def parse_time_interval(interval):
+    if isinstance(interval, int):
+        return timedelta(seconds=interval)
+    if isinstance(interval, str) \
+    and interval != '':
+        m = re.match(r'(?:(\d+)d)?(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s?)?$', interval)
+        if m:
+            return timedelta(
+                days=int(m.group(1) or 0),
+                hours=int(m.group(2) or 0),
+                minutes=int(m.group(3) or 0),
+                seconds=int(m.group(4) or 0)
+            )
+        else:
+            return None
+    return None
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None, **_):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        anarchy_output_dir = task_vars['anarchy_output_dir']
+        module_args = self._task.args.copy()
+        after = module_args.get('after', None)
+
+        if not after:
+            return dict(
+                failed = True,
+                message = 'Parameter `after` is required',
+            )
+
+        interval = parse_time_interval(after)
+        if interval:
+            after = (datetime.utcnow() + interval).strftime('%FT%TZ')
+        else:
+            return dict(
+                failed = True,
+                message = 'Parameter `after` must be time interval. Ex: 1h, 10m, 30s',
+            )
+
+        with open(os.path.join(anarchy_output_dir, 'continue.yaml'), 'w') as f:
+            yaml.safe_dump({'after': int(interval.total_seconds())}, f)
+
+        return dict(
+            after = int(interval.total_seconds()),
+            failed = False,
+        )

--- a/anarchy-runner/ansible-runner/project/action_plugins/anarchy_finish_action.py
+++ b/anarchy-runner/ansible-runner/project/action_plugins/anarchy_finish_action.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python
+
+# Copyright: (c) 2019, Johnathan Kupferer <jkupfere@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import os
+import re
+import requests
+
+from ansible.plugins.action import ActionBase
+from ansible.module_utils.parsing.convert_bool import boolean
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None, **_):
+        result = super(ActionModule, self).run(tmp, task_vars)
+        module_args = self._task.args.copy()
+        anarchy_action_name = task_vars.get('anarchy_action_name')
+        anarchy_subject_name = task_vars['anarchy_subject_name']
+        anarchy_url = task_vars['anarchy_url']
+        anarchy_run_pod_name = task_vars['anarchy_run_pod_name']
+        anarchy_runner_name = task_vars['anarchy_runner_name']
+        anarchy_runner_token = task_vars['anarchy_runner_token']
+
+        finished_state = module_args.get('state', 'successful')
+
+        if not anarchy_action_name:
+            return dict(
+                failed = True,
+                msg = 'Run not executing for an action!'
+            )
+
+        response = requests.patch(
+            anarchy_url + '/run/subject/' + anarchy_subject_name + '/actions/' + anarchy_action_name,
+            headers={'Authorization': 'Bearer {}:{}:{}'.format(
+                anarchy_runner_name, anarchy_run_pod_name, anarchy_runner_token
+            )},
+            json={finished_state: True}
+        )
+        result['action'] = response.json()['result']
+        result['failed'] = not response.json()['success']
+
+        return result

--- a/helm/crds/anarchyactions.yaml
+++ b/helm/crds/anarchyactions.yaml
@@ -158,7 +158,7 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     name:
                       type: string
-              completedTimestamp:
+              finishedTimestamp:
                 description: >-
                   Timestamp for when the action is completed.
                   Once an action is completed no further callbacks are accepted for it and it is subject to cleanup
@@ -179,4 +179,6 @@ spec:
                   uid:
                     type: string
               runScheduled:
+                type: string
+              state:
                 type: string

--- a/helm/crds/anarchyactions.yaml
+++ b/helm/crds/anarchyactions.yaml
@@ -73,7 +73,7 @@ spec:
                 type: string
               after:
                 description: >-
-                  Datetime string in for format "YYYY-MM-DDThh:mm:ssZ". AnarchyRun will be created
+                  Timestamp string in for format "YYYY-MM-DDThh:mm:ssZ". AnarchyRun will be created
                   for the AnarchyAction after this time.
                 type: string
               callbackToken:
@@ -158,6 +158,13 @@ spec:
                       x-kubernetes-preserve-unknown-fields: true
                     name:
                       type: string
+              completedTimestamp:
+                description: >-
+                  Timestamp for when the action is completed.
+                  Once an action is completed no further callbacks are accepted for it and it is subject to cleanup
+                  operations. No subsequent actions are released for run on a subject until previous actions are
+                  completed.
+                type: string
               runRef:
                 type: object
                 properties:

--- a/helm/crds/anarchygovernors.yaml
+++ b/helm/crds/anarchygovernors.yaml
@@ -98,6 +98,11 @@ spec:
                 additionalProperties:
                   type: object
                   properties:
+                    explicitCompletion:
+                      description: >-
+                        Flag to indicate whether this action should automatically be marked as complete upon successful run.
+                        If set to true then the run or a callback handler must explicitly mark the action as complete.
+                      type: boolean
                     tasks:
                       description: >-
                         Ansible "tasks" for the dynamic ansible play used to run this action.

--- a/helm/crds/anarchygovernors.yaml
+++ b/helm/crds/anarchygovernors.yaml
@@ -48,9 +48,9 @@ spec:
                 description: >-
                   AnsibleRunner that should process AnsibleRuns for this governor.
                 type: string
-              removeSuccessfulActions:
+              removeFinishedActions:
                 description: >-
-                  Specification for removing AnarchyActions after successful completion.
+                  Specification for removing AnarchyActions after they are finished.
                 type: object
                 properties:
                   after:

--- a/helm/crds/anarchygovernors.yaml
+++ b/helm/crds/anarchygovernors.yaml
@@ -98,10 +98,11 @@ spec:
                 additionalProperties:
                   type: object
                   properties:
-                    explicitCompletion:
+                    finishOnSuccessfulRun:
                       description: >-
-                        Flag to indicate whether this action should automatically be marked as complete upon successful run.
-                        If set to true then the run or a callback handler must explicitly mark the action as complete.
+                        Flag to indicate whether this action should be marked as finished automatically
+                        on a successful run or otherwise requires an explicit callback from the runner
+                        using anarchy_finish_action to be marked as finished. Defaults to true.
                       type: boolean
                     tasks:
                       description: >-

--- a/helm/crds/anarchyruns.yaml
+++ b/helm/crds/anarchyruns.yaml
@@ -285,6 +285,14 @@ spec:
                                         ok:
                                           description: Whether the task was successful for tasks without loops.
                                           type: boolean
+                                        failed:
+                                          type: boolean
+                                        skipped:
+                                          type: boolean
+                                        args:
+                                          description: Arguments for task
+                                          type: object
+                                          x-kubernetes-preserve-unknown-fields: true
                                         result:
                                           description: Result of task execution for tasks without loops.
                                           type: object
@@ -296,9 +304,13 @@ spec:
                                             description: Task item information for tasks with loops
                                             type: object
                                             properties:
-                                              label:
+                                              item:
                                                 type: string
                                               ok:
+                                                type: boolean
+                                              failed:
+                                                type: boolean
+                                              skipped:
                                                 type: boolean
                                               result:
                                                 description: Result of task item execution

--- a/helm/templates/anarchyrunner.yaml
+++ b/helm/templates/anarchyrunner.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: runner
-        resources: 
+        resources:
           {{- toYaml $runner.resources | nindent 10 }}
       serviceAccountName: {{ $serviceAccountName }}
 {{- if $runner.token }}

--- a/institutions/gitops/k8s-config/vars.yaml
+++ b/institutions/gitops/k8s-config/vars.yaml
@@ -5,7 +5,7 @@ k8s_resources:
 - name: Anarchy install
   openshift_template:
     url: https://raw.githubusercontent.com/redhat-cop/anarchy/{{ anarchy_version }}/install-template.yaml
-    
+
 - namespace: anarchy-k8s-config
   resources:
   - name: Anarchy k8s-config deployment

--- a/operator/anarchyaction.py
+++ b/operator/anarchyaction.py
@@ -177,6 +177,8 @@ class AnarchyAction(object):
                 }
             )
             self.refresh_from_resource(resource)
+            # Remove action from cache as it will not appear in watch when run label is set
+            AnarchyAction.cache_remove(self.name)
         except kubernetes.client.rest.ApiException as e:
             # If error is 404, not found, then subject or action must have been deleted
             if e.status != 404:

--- a/operator/anarchyaction.py
+++ b/operator/anarchyaction.py
@@ -381,10 +381,6 @@ class AnarchyAction(object):
         )
 
     def start(self, runtime):
-        if self.status:
-            operator_logger.warning('START %s %s %s', self.name, self.after_datetime.strftime('%FT%TZ'), self.status.get('runScheduled', '-none-'))
-        else:
-            operator_logger.warning('START %s %s %s', self.name, self.after_datetime.strftime('%FT%TZ'), '-')
         subject = self.get_subject(runtime)
 
         # Attempt to set active action for subject

--- a/operator/anarchygovernor.py
+++ b/operator/anarchygovernor.py
@@ -224,8 +224,8 @@ class AnarchyGovernor(object):
         return self.spec.get('pythonRequirements', None)
 
     @property
-    def remove_successful_actions_after(self):
-        time_interval = self.spec.get('removeSuccessfulActions', {}).get('after')
+    def remove_finished_actions_after(self):
+        time_interval = self.spec.get('removeFinishedActions', {}).get('after')
         if time_interval:
             return parse_time_interval(time_interval)
         else:
@@ -265,45 +265,26 @@ class AnarchyGovernor(object):
             return None
 
     def cleanup_actions(self, runtime):
-        time_interval = self.remove_successful_actions_after
+        """
+        Delete AnarchyActions that have finished a while ago, configured by spec.removeFinishedActions.after
+        """
+        time_interval = self.remove_finished_actions_after
         if not isinstance(time_interval, timedelta):
             return
         for action_resource in runtime.custom_objects_api.list_namespaced_custom_object(
             runtime.operator_domain, runtime.api_version, runtime.operator_namespace, 'anarchyactions',
-            label_selector='{}={},{}'.format(runtime.governor_label, self.name, runtime.run_label)
+            label_selector='{}={},{}'.format(runtime.governor_label, self.name, runtime.finished_label)
         ).get('items', []):
             action_name = action_resource['metadata']['name']
-            run_name = action_resource.get('status', {}).get('runRef', {}).get('name')
-            run_scheduled_timestamp = action_resource.get('status', {}).get('runScheduled')
-            if not run_name or not run_scheduled_timestamp:
-                operator_logger.warning(
-                    'AnarchyAction %s has label %s but status does not have runRef or runScheduled',
-                    action_name, runtime.run_label
-                )
+            # If action has no finishedTimestamp than do not delete
+            finished_timestamp = action_resource.get('status', {}).get('finishedTimestamp')
+            if not finished_timestamp:
                 continue
 
-            run_scheduled_datetime = datetime.strptime(run_scheduled_timestamp, '%Y-%m-%dT%H:%M:%SZ')
-
-            # If run has not be scheduled longer ago than the interval then do not delete
-            if run_scheduled_datetime + time_interval > datetime.utcnow():
+            # If action has not finished longer ago than the interval then do not delete
+            finished_datetime = datetime.strptime(finished_timestamp, '%Y-%m-%dT%H:%M:%SZ')
+            if finished_datetime + time_interval > datetime.utcnow():
                 continue
-
-            try:
-                run_resource = runtime.custom_objects_api.get_namespaced_custom_object(
-                    runtime.operator_domain, runtime.api_version, runtime.operator_namespace, 'anarchyruns', run_name
-                )
-                # If run has not posted a successful result longer ago than the interval then do not delete
-                if run_resource['metadata']['labels'][runtime.runner_label] != 'successful':
-                    continue
-
-                # If run has not posted a result longer ago than the interval then do not delete
-                run_post_datetime = datetime.strptime(run_resource['spec']['runPostTimestamp'], '%Y-%m-%dT%H:%M:%SZ')
-                if run_post_datetime + time_interval > datetime.utcnow():
-                    continue
-            except kubernetes.client.rest.ApiException as e:
-                # If run is already deleted then action may be deleted
-                if e.status != 404:
-                    raise
 
             try:
                 runtime.custom_objects_api.delete_namespaced_custom_object(
@@ -314,6 +295,9 @@ class AnarchyGovernor(object):
                     raise
 
     def cleanup_runs(self, runtime):
+        """
+        Delete AnarchyRuns that have posted results a while ago, configured by spec.removeSuccessfulRuns.after
+        """
         time_interval = self.remove_successful_runs_after
         if not isinstance(time_interval, timedelta):
             return
@@ -322,16 +306,23 @@ class AnarchyGovernor(object):
             label_selector='{}={},{}=successful'.format(runtime.governor_label, self.name, runtime.runner_label)
         ).get('items', []):
             run_name = run_resource['metadata']['name']
+            # If run has no runPostTimestamp than do not delete
+            run_post_timestamp = run_resource.get('spec', {}).get('runPostTimestamp')
+            if not run_post_timestamp:
+                continue
+
             # If run has not posted a result longer ago than the interval then do not delete
-            run_post_datetime = datetime.strptime(run_resource['spec']['runPostTimestamp'], '%Y-%m-%dT%H:%M:%SZ')
-            if run_post_datetime + time_interval < datetime.utcnow():
-                try:
-                    runtime.custom_objects_api.delete_namespaced_custom_object(
-                        runtime.operator_domain, runtime.api_version, runtime.operator_namespace, 'anarchyruns', run_name
-                    )
-                except kubernetes.client.rest.ApiException as e:
-                    if e.status != 404:
-                        raise
+            run_post_datetime = datetime.strptime(run_post_timestamp, '%Y-%m-%dT%H:%M:%SZ')
+            if run_post_datetime + time_interval > datetime.utcnow():
+                continue
+
+            try:
+                runtime.custom_objects_api.delete_namespaced_custom_object(
+                    runtime.operator_domain, runtime.api_version, runtime.operator_namespace, 'anarchyruns', run_name
+                )
+            except kubernetes.client.rest.ApiException as e:
+                if e.status != 404:
+                    raise
 
     def get_parameters(self, runtime, api, anarchy_subject, action_config):
         parameters = {}

--- a/operator/anarchygovernor.py
+++ b/operator/anarchygovernor.py
@@ -53,7 +53,20 @@ class AnarchyGovernor(object):
 
         @property
         def callback_name_parameter(self):
+            """
+            Optional configuration setting to allow the action callback name to be
+            specified in the callback data rather than as a URL component to the
+            API.
+            """
             return self.spec.get('callbackNameParameter', None)
+
+        @property
+        def explicit_completion(self):
+            """
+            Boolean flag indicating whether actions using this action config require
+            an explicit api call be marked complete. Defaults to False.
+            """
+            return self.spec.get('explicitCompletion', False)
 
         @property
         def post_tasks(self):
@@ -291,7 +304,7 @@ class AnarchyGovernor(object):
                 # If run is already deleted then action may be deleted
                 if e.status != 404:
                     raise
-            
+
             try:
                 runtime.custom_objects_api.delete_namespaced_custom_object(
                     runtime.operator_domain, runtime.api_version, runtime.operator_namespace, 'anarchyactions', action_name

--- a/operator/anarchygovernor.py
+++ b/operator/anarchygovernor.py
@@ -61,12 +61,12 @@ class AnarchyGovernor(object):
             return self.spec.get('callbackNameParameter', None)
 
         @property
-        def explicit_completion(self):
+        def finish_on_successful_run(self):
             """
-            Boolean flag indicating whether actions using this action config require
-            an explicit api call be marked complete. Defaults to False.
+            Boolean flag indicating whether actions using this action config are
+            automatically marked finished after a successful run. Defaults to True.
             """
-            return self.spec.get('explicitCompletion', False)
+            return self.spec.get('finishOnSuccessfulRun', True)
 
         @property
         def post_tasks(self):

--- a/operator/anarchyrun.py
+++ b/operator/anarchyrun.py
@@ -76,6 +76,12 @@ class AnarchyRun(object):
         pass
 
     @property
+    def action_name(self):
+        action = self.spec.get('action')
+        if action:
+            return action['name']
+
+    @property
     def creation_timestamp(self):
         return self.metadata.get('creationTimestamp')
 

--- a/operator/anarchysubject.py
+++ b/operator/anarchysubject.py
@@ -51,6 +51,20 @@ class AnarchySubject(object):
             'subjects must define governor'
 
     @property
+    def active_action_name(self):
+        ref = self.active_action_ref
+        if ref:
+            return ref['name']
+        else:
+            return None
+
+    @property
+    def active_action_ref(self):
+        if not self.status:
+            return None
+        return self.status.get('activeAction')
+
+    @property
     def active_run_name(self):
         ref = self.active_run_ref
         if ref:
@@ -157,7 +171,7 @@ class AnarchySubject(object):
                 if e.status == 409:
                     # Conflict, refresh subject from api and retry
                     if not self.refresh_from_api(runtime):
-                        operator_logger.error('Cannot add run to status, unable to refresh AnarchySubject %s', self.subject_name)
+                        operator_logger.error('Cannot add run to status, unable to refresh AnarchySubject %s', self.name)
                         return
                 else:
                     raise
@@ -175,9 +189,6 @@ class AnarchySubject(object):
         if not governor:
             operator_logger.error('Unable to find governor %s', self.governor_name)
         return governor
-
-    def get_anarchy_run(self, runtime):
-        return self.anarchy_runs.get(self.current_anarchy_run, None)
 
     def handle_create(self, runtime):
         self.add_finalizer(runtime)
@@ -250,7 +261,7 @@ class AnarchySubject(object):
                     # Conflict, refresh subject from api and retry
                     first_attempt = False
                     if not self.refresh_from_api(runtime):
-                        operator_logger.info('Cannot remove active run from status, unable to refresh AnarchySubject %s', self.subject_name)
+                        operator_logger.info('Cannot remove active run from status, unable to refresh AnarchySubject %s', self.name)
                         return
                 else:
                     raise
@@ -331,6 +342,63 @@ class AnarchySubject(object):
         self.spec = resource['spec']
         self.status = resource.get('status')
 
+    def remove_active_action(self, action, runtime):
+        """Attempt to remove activeAction in AnarchySubject status.
+        If a different action is already active then no change will be made.
+
+        Parameters
+        ----------
+        action : AnarchyAction
+            The action to remove as active.
+        runtime : AnarchyRuntime
+            Object with runtime configuration and k8s APIs
+
+        Raises
+        ------
+        kubernetes.client.rest.ApiException
+            Exception communicating with the k8s API
+
+        Returns
+        -------
+        bool
+            Indication of whether active action was successfully removed.
+        """
+        while True:
+            if not self.active_action_ref \
+            or self.active_action_ref['name'] != action.name:
+                return
+
+            anarchy_subject = self.to_dict(runtime)
+            anarchy_subject['status'].pop('activeAction', None)
+
+            try:
+                operator_logger.info(
+                    'Removing activeAction %s for AnarchySubject %s',
+                    action.name, self.name
+                )
+                resource = runtime.custom_objects_api.replace_namespaced_custom_object_status(
+                    runtime.operator_domain, runtime.api_version, self.namespace, 'anarchysubjects', self.name, anarchy_subject
+                )
+                self.refresh_from_resource(resource)
+                return True
+            except kubernetes.client.rest.ApiException as e:
+                if e.status == 409:
+                    # Conflict, refresh subject from api and retry
+                    if not self.refresh_from_api(runtime):
+                        operator_logger.error(
+                            'Cannot remove activeAction from status, unable to refresh AnarchySubject %s',
+                            self.name
+                        )
+                        return False
+                elif e.status == 404:
+                    operator_logger.warning(
+                        'Cannot remove activeAction from status, AnarchySubject %s was deleted',
+                        self.name
+                    )
+                    return False
+                else:
+                    raise
+
     def remove_active_run(self, run_ref, runtime):
         while True:
             anarchy_subject = self.to_dict(runtime)
@@ -363,15 +431,107 @@ class AnarchySubject(object):
                     raise
 
     def remove_finalizers(self, runtime):
-        return runtime.custom_objects_api.patch_namespaced_custom_object(
-            runtime.operator_domain, runtime.api_version, runtime.operator_namespace, 'anarchysubjects', self.name,
-            {'metadata': {'finalizers': None } }
+        """Remove finalizers from AnarchySubject metadata to allow delete to complete.
+
+        Parameters
+        ----------
+        runtime : AnarchyRuntime
+            Object with runtime configuration and k8s APIs
+
+        Raises
+        ------
+        kubernetes.client.rest.ApiException
+            Exception communicating with the k8s API
+        """
+        try:
+            return runtime.custom_objects_api.patch_namespaced_custom_object(
+                runtime.operator_domain, runtime.api_version, runtime.operator_namespace, 'anarchysubjects', self.name,
+                {'metadata': {'finalizers': None } }
+            )
+        except kubernetes.client.rest.ApiException as e:
+            if e.status != 404:
+                raise
+
+    def set_active_action(self, action, runtime):
+        """Attempt to set activeAction in AnarchySubject status.
+        If a different action is already active then no change will be made.
+
+        Parameters
+        ----------
+        action : AnarchyAction
+            The action to set as active.
+        runtime : AnarchyRuntime
+            Object with runtime configuration and k8s APIs
+
+        Raises
+        ------
+        kubernetes.client.rest.ApiException
+            Exception communicating with the k8s API
+
+        Returns
+        -------
+        bool
+            Indication of whether active action was set successfully.
+        """
+        set_action_ref = dict(
+            apiVersion = runtime.api_group_version,
+            kind = 'AnarchyAction',
+            name = action.name,
+            namespace = action.namespace,
+            uid = action.uid
         )
+        while True:
+            action_ref = self.active_action_ref
+            if action_ref:
+               if action_ref['uid'] == set_action_ref['uid']:
+                   return True
+               else:
+                   return False
+
+            anarchy_subject = self.to_dict(runtime)
+            if anarchy_subject['status'] == None:
+                anarchy_subject['status'] = dict(
+                    activeAction = set_action_ref
+                )
+            else:
+                anarchy_subject['status']['activeAction'] = set_action_ref
+
+            try:
+                operator_logger.info(
+                    'Setting AnarchyAction %s to active for AnarchySubject %s',
+                    action.name, self.name
+                )
+                resource = runtime.custom_objects_api.replace_namespaced_custom_object_status(
+                    runtime.operator_domain, runtime.api_version, self.namespace, 'anarchysubjects', self.name, anarchy_subject
+                )
+                self.refresh_from_resource(resource)
+                return True
+            except kubernetes.client.rest.ApiException as e:
+                if e.status == 409:
+                    # Conflict, refresh subject from api and retry
+                    if not self.refresh_from_api(runtime):
+                        operator_logger.error(
+                            'Cannot set activeAction in status, unable to refresh AnarchySubject %s',
+                            self.name
+                        )
+                        return False
+                else:
+                    raise
 
     def set_active_run_to_pending(self, runtime):
-        '''
-        Set next AnarchyRun to pending
-        '''
+        """Patch AnarchyRun listed as active in AnarchySubject to pending state.
+        If AnarchyRun is not found then it is removed from the subject.
+
+        Parameters
+        ----------
+        runtime : AnarchyRuntime
+            Object with runtime configuration and k8s APIs
+
+        Raises
+        ------
+        kubernetes.client.rest.ApiException
+            Exception communicating with the k8s API
+        """
         while True:
             run_ref = self.active_run_ref
             if not run_ref:
@@ -394,6 +554,7 @@ class AnarchySubject(object):
                     self.remove_active_run(run_ref, runtime)
                 else:
                     raise
+
     def set_run_failure_in_status(self, anarchy_run, runtime):
         resource = runtime.custom_objects_api.patch_namespaced_custom_object_status(
             runtime.operator_domain, runtime.api_version, runtime.operator_namespace,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp==3.6.2
 aiojobs==0.2.2
-ansible==2.9.13
+ansible==2.9.16
 ansible-runner==1.4.6
 async-timeout==3.0.1
 attrs==19.3.0
@@ -22,7 +22,7 @@ Jinja2==2.11.2
 jmespath==0.10.0
 jsonpatch==1.25
 jsonpointer==2.0
-kopf==0.27
+kopf==0.28.3
 kubernetes==11.0.0
 lockfile==0.12.2
 MarkupSafe==1.1.1

--- a/test/roles/anarchy_test_babylon/defaults/main.yaml
+++ b/test/roles/anarchy_test_babylon/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 anarchy_test_babylon_anarchy_governor_repo: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
-anarchy_test_babylon_anarchy_governor_version: jkupferer-add-action-completion
+anarchy_test_babylon_anarchy_governor_version: v0.5.0
 #anarchy_test_babylon_schedule_destroy_after_provision:
 #anarchy_test_babylon_schedule_stop_after_provision:
 #anarchy_test_babylon_schedule_stop_after_start:

--- a/test/roles/anarchy_test_babylon/defaults/main.yaml
+++ b/test/roles/anarchy_test_babylon/defaults/main.yaml
@@ -1,6 +1,6 @@
 ---
 anarchy_test_babylon_anarchy_governor_repo: https://github.com/redhat-gpte-devopsautomation/babylon_anarchy_governor.git
-anarchy_test_babylon_anarchy_governor_version: v0.1.12
+anarchy_test_babylon_anarchy_governor_version: jkupferer-add-action-completion
 #anarchy_test_babylon_schedule_destroy_after_provision:
 #anarchy_test_babylon_schedule_stop_after_provision:
 #anarchy_test_babylon_schedule_stop_after_start:

--- a/test/roles/anarchy_test_babylon/tasks/test.yaml
+++ b/test/roles/anarchy_test_babylon/tasks/test.yaml
@@ -24,9 +24,8 @@
   - r_test_1_provision.resources[0].spec.action == 'provision'
   - r_test_1_provision.resources[0].status is defined
   - r_test_1_provision.resources[0].status.callbackEvents is defined
-  - r_test_1_provision.resources[0].status.callbackEvents | length == 2
-  - r_test_1_provision.resources[0].status.callbackEvents[0].name == 'started'
-  - r_test_1_provision.resources[0].status.callbackEvents[1].name == 'complete'
+  - r_test_1_provision.resources[0].status.callbackEvents | length == 1
+  - r_test_1_provision.resources[0].status.callbackEvents[0].name == 'complete'
   retries: 20
   delay: 5
 
@@ -42,7 +41,6 @@
   - r_test_1_subject.resources[0].spec.vars.current_state == 'started'
   - r_test_1_subject.resources[0].status.towerJobs is defined
   - r_test_1_subject.resources[0].status.towerJobs.provision is defined
-  - r_test_1_subject.resources[0].status.towerJobs.provision.launchJob is defined
   - r_test_1_subject.resources[0].status.towerJobs.provision.deployerJob is defined
   retries: 5
   delay: 5

--- a/test/roles/anarchy_test_babylon/tasks/test.yaml
+++ b/test/roles/anarchy_test_babylon/tasks/test.yaml
@@ -116,3 +116,63 @@
     until: r_get_test_babylon_1_subject is success
     retries: 20
     delay: 5
+
+- name: Create AnarchySubject test-babylon-2
+  k8s:
+    apply: true
+    state: present
+    definition: "{{ lookup('template', 'subject.yaml.j2') | from_yaml }}"
+  vars:
+    _name: test-babylon-2
+    _vars:
+      desired_state: started
+      tower_job_check_interval: 10s
+      job_vars:
+        simulate_job_result: failed
+
+- name: Wait for test-babylon-2 subject provision-failed
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    name: test-babylon-2
+    namespace: "{{ anarchy_namespace }}"
+  register: r_test_subject
+  until:
+  - r_test_subject.resources[0].metadata.labels.state | default('') == 'provision-failed'
+  - r_test_subject.resources[0].spec.vars.current_state | default('')  == 'provision-failed'
+  retries: 20
+  delay: 5
+
+- name: Update AnarchySubject test-babylon-2 simulate_job_result
+  k8s:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    name: test-babylon-2
+    namespace: "{{ anarchy_namespace }}"
+    definition:
+      spec:
+        vars:
+          job_vars:
+            simulate_job_result: successful
+
+- when: anarchy_test_delete_subjects | bool
+  block:
+  - name: Delete test-babylon-2 subject
+    k8s:
+      state: absent
+      api_version: anarchy.gpte.redhat.com/v1
+      kind: AnarchySubject
+      name: test-babylon-2
+      namespace: "{{ anarchy_namespace }}"
+
+  - name: Verify AnarchySubject delete for test-babylon-2
+    k8s_info:
+      api_version: anarchy.gpte.redhat.com/v1
+      kind: AnarchySubject
+      name: test-babylon-2
+      namespace: "{{ anarchy_namespace }}"
+    register: r_get_test_babylon_2_subject
+    failed_when: r_get_test_babylon_2_subject.resources | default([]) | length != 0
+    until: r_get_test_babylon_2_subject is success
+    retries: 20
+    delay: 5

--- a/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
+++ b/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
@@ -58,9 +58,6 @@ spec:
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
-        started:
-          roles:
-          - role: babylon_anarchy_governor
         complete:
           roles:
           - role: babylon_anarchy_governor
@@ -69,9 +66,6 @@ spec:
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
-        started:
-          roles:
-          - role: babylon_anarchy_governor
         complete:
           roles:
           - role: babylon_anarchy_governor
@@ -80,9 +74,6 @@ spec:
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
-        started:
-          roles:
-          - role: babylon_anarchy_governor
         complete:
           roles:
           - role: babylon_anarchy_governor
@@ -91,9 +82,6 @@ spec:
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
-        started:
-          roles:
-          - role: babylon_anarchy_governor
         complete:
           roles:
           - role: babylon_anarchy_governor

--- a/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
+++ b/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
@@ -54,7 +54,7 @@ spec:
   actions:
     # anarchy_action_name
     provision:
-      explicitCompletion: true
+      finishOnSuccessfulRun: false
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
@@ -65,7 +65,7 @@ spec:
           roles:
           - role: babylon_anarchy_governor
     stop:
-      explicitCompletion: true
+      finishOnSuccessfulRun: false
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
@@ -76,7 +76,7 @@ spec:
           roles:
           - role: babylon_anarchy_governor
     start:
-      explicitCompletion: true
+      finishOnSuccessfulRun: false
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
@@ -87,7 +87,7 @@ spec:
           roles:
           - role: babylon_anarchy_governor
     destroy:
-      explicitCompletion: true
+      finishOnSuccessfulRun: false
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:

--- a/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
+++ b/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
@@ -10,6 +10,9 @@ metadata:
     anarchy.gpte.redhat.com/test: babylon
 spec:
   ansibleGalaxyRequirements:
+    collections:
+    - name: awx.awx
+      version: 15.0.1
     roles:
     - name: babylon_anarchy_governor
       src: {{ ('git+' ~ anarchy_test_babylon_anarchy_governor_repo) | to_json }}
@@ -23,6 +26,9 @@ spec:
     # Job variables to pass to Ansible Tower job runner (dark tower)
     job_vars:
       __meta__:
+        deployer:
+          scm_url: https://github.com/redhat-cop/agnosticd.git
+          scm_ref: development
         tower:
           organization: {{ anarchy_test_babylon_account | to_json }}
       job_var_from_governor: governor
@@ -48,6 +54,7 @@ spec:
   actions:
     # anarchy_action_name
     provision:
+      explicitCompletion: true
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
@@ -58,6 +65,7 @@ spec:
           roles:
           - role: babylon_anarchy_governor
     stop:
+      explicitCompletion: true
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
@@ -68,6 +76,7 @@ spec:
           roles:
           - role: babylon_anarchy_governor
     start:
+      explicitCompletion: true
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:
@@ -78,6 +87,7 @@ spec:
           roles:
           - role: babylon_anarchy_governor
     destroy:
+      explicitCompletion: true
       roles:
       - role: babylon_anarchy_governor
       callbackHandlers:

--- a/test/roles/anarchy_test_simple/tasks/test.yaml
+++ b/test/roles/anarchy_test_simple/tasks/test.yaml
@@ -493,7 +493,7 @@
   retries: 20
   delay: 5
 
-- name: Verify AnarchyAction test-simple-1-callback-test completed
+- name: Verify AnarchyAction test-simple-1-callback-test finished
   k8s_info:
     api_version: anarchy.gpte.redhat.com/v1
     kind: AnarchyAction
@@ -503,7 +503,8 @@
   vars:
     _action: "{{ r_get_action.resources[0] }}"
   failed_when: >-
-    '' == _action.status.completedTimestamp | default('')
+    '' == _action.status.finishedTimestamp | default('') or
+    'successful' != _action.status.state | default('')
   until: r_get_action is success
   retries: 10
   delay: 5

--- a/test/roles/anarchy_test_simple/tasks/test.yaml
+++ b/test/roles/anarchy_test_simple/tasks/test.yaml
@@ -386,6 +386,143 @@
   retries: 20
   delay: 5
 
+- name: Create AnarchyAction to test callback functionality
+  k8s:
+    apply: true
+    state: present
+    definition:
+      apiVersion: anarchy.gpte.redhat.com/v1
+      kind: AnarchyAction
+      metadata:
+        name: test-simple-1-callback-test
+        namespace:  "{{ anarchy_namespace }}"
+      spec:
+        action: callback_test
+        callbackToken: c4llb4ckT0k3n
+        subjectRef:
+          name: test-simple-1
+
+- name: Verify run of AnarchyAction test-simple-1-callback-test
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyAction
+    namespace: "{{ anarchy_namespace }}"
+    name: test-simple-1-callback-test
+  register: r_get_action
+  vars:
+    _action: "{{ r_get_action.resources[0] }}"
+  failed_when: >-
+    'runRef' not in _action.status | default({})
+  until: r_get_action is success
+  retries: 10
+  delay: 5
+
+- name: Check AnarchyRun for test-simple-1-fail-first-run
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyRun
+    namespace: "{{ anarchy_namespace }}"
+    name: "{{ _run_ref.name }}"
+  register: r_get_run
+  vars:
+    _action: "{{ r_get_action.resources[0] }}"
+    _run_ref: "{{ _action.status.runRef }}"
+    _run: "{{ r_get_run.resources[0] }}"
+  failed_when: >-
+    _run.spec.result.status | default('') != 'successful'
+  until: r_get_run is success
+  retries: 20
+  delay: 5
+
+- name: Verify run of AnarchyAction test-simple-1-callback-test not yet completed
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyAction
+    namespace: "{{ anarchy_namespace }}"
+    name: test-simple-1-callback-test
+  register: r_get_action
+  vars:
+    _action: "{{ r_get_action.resources[0] }}"
+  failed_when: >-
+    _action.status.completedTimestamp | default(false)
+  until: r_get_action is success
+  retries: 10
+  delay: 5
+
+- name: Verify AnarchyAction test-simple-1-callback-test still active for AnarchySubject
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    namespace: "{{ anarchy_namespace }}"
+    name: test-simple-1
+  register: r_get_subject
+  vars:
+    _subject: "{{ r_get_subject.resources[0] }}"
+  failed_when: >-
+    'test-simple-1-callback-test' != _subject.status.activeAction.name | default('')
+  until: r_get_subject is success
+  retries: 10
+  delay: 5
+
+- name: Execute callback for test-simple-1-callback-test
+  uri:
+    url: "{{ anarchy_callback_base_url }}/action/test-simple-1-callback-test"
+    validate_certs: false
+    method: POST
+    headers:
+      Authorization: 'Bearer c4llb4ckT0k3n'
+    body_format: json
+    body:
+      event: done
+
+- name: Check AnarchyRun for test-simple-1-callback-test done event
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyRun
+    namespace: "{{ anarchy_namespace }}"
+    label_selectors:
+    - anarchy.gpte.redhat.com/subject=test-simple-1
+    - anarchy.gpte.redhat.com/action=test-simple-1-callback-test
+    - anarchy.gpte.redhat.com/event=done
+  register: r_get_run
+  vars:
+    _run: "{{ r_get_run.resources[0] }}"
+  failed_when: >-
+    _run.spec.result.status | default('') != 'successful'
+  until: r_get_run is success
+  retries: 20
+  delay: 5
+
+- name: Verify AnarchyAction test-simple-1-callback-test completed
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyAction
+    namespace: "{{ anarchy_namespace }}"
+    name: test-simple-1-callback-test
+  register: r_get_action
+  vars:
+    _action: "{{ r_get_action.resources[0] }}"
+  failed_when: >-
+    '' == _action.status.completedTimestamp | default('')
+  until: r_get_action is success
+  retries: 10
+  delay: 5
+
+- name: Verify no AnarchyAction active for test-simple-1
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    namespace: "{{ anarchy_namespace }}"
+    name: test-simple-1
+  register: r_get_subject
+  vars:
+    _subject: "{{ r_get_subject.resources[0] }}"
+  failed_when: >-
+    '' != _subject.status.activeAction.name | default('')
+  until: r_get_subject is success
+  retries: 10
+  delay: 5
+
 - when: anarchy_test_delete_subjects | bool
   block:
   - name: Delete AnarchySubject test-simple-1

--- a/test/roles/anarchy_test_simple/tasks/test.yaml
+++ b/test/roles/anarchy_test_simple/tasks/test.yaml
@@ -524,6 +524,76 @@
   retries: 10
   delay: 5
 
+- name: Create AnarchyAction to test action continuation
+  k8s:
+    apply: true
+    state: present
+    definition:
+      apiVersion: anarchy.gpte.redhat.com/v1
+      kind: AnarchyAction
+      metadata:
+        name: test-simple-1-continuation-test
+        namespace:  "{{ anarchy_namespace }}"
+      spec:
+        action: continuation_test
+        subjectRef:
+          name: test-simple-1
+
+- name: Check first AnarchyRun for test-simple-1-continuation-test
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyRun
+    namespace: "{{ anarchy_namespace }}"
+    label_selectors:
+    - anarchy.gpte.redhat.com/subject=test-simple-1
+    - anarchy.gpte.redhat.com/action=test-simple-1-continuation-test
+  register: r_get_run
+  vars:
+    _run: "{{ r_get_run.resources[0] }}"
+  failed_when: >-
+    _run.spec.result.status | default('') != 'successful'
+  until: r_get_run is success
+  retries: 20
+  delay: 5
+
+- name: Pause briefely for AnarchyRun processing
+  pause:
+    seconds: 2
+
+- name: Check that test-simple-1-continuation-test is not finished
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyAction
+    namespace: "{{ anarchy_namespace }}"
+    name: test-simple-1-continuation-test
+  register: r_get_action
+  vars:
+    _action: "{{ r_get_action.resources[0] }}"
+  failed_when: >-
+    _action.status.finishedTimestamp | default('') != ''
+  until: r_get_action is success
+  retries: 20
+  delay: 5
+
+- name: Pause for second AnarchyRun
+  pause:
+    seconds: 30
+
+- name: Check that test-simple-1-continuation-test is finished
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchyAction
+    namespace: "{{ anarchy_namespace }}"
+    name: test-simple-1-continuation-test
+  register: r_get_action
+  vars:
+    _action: "{{ r_get_action.resources[0] }}"
+  failed_when: >-
+    _action.status.finishedTimestamp | default('') == ''
+  until: r_get_action is success
+  retries: 20
+  delay: 5
+
 - when: anarchy_test_delete_subjects | bool
   block:
   - name: Delete AnarchySubject test-simple-1

--- a/test/roles/anarchy_test_simple/templates/governor.yaml.j2
+++ b/test/roles/anarchy_test_simple/templates/governor.yaml.j2
@@ -62,6 +62,19 @@ spec:
         failed_when: >-
           "module is required" in r_mysql_info.msg
 
+    callback_test:
+      explicitCompletion: true
+      tasks:
+      - name: Print message
+        debug:
+          msg: Starting callback test
+      callbackNameParameter: event
+      callbackHandlers:
+        done:
+          tasks:
+          - name: Explicitly complete action
+            anarchy_complete_action: {}
+
     destroy:
       tasks:
       - name: Print message

--- a/test/roles/anarchy_test_simple/templates/governor.yaml.j2
+++ b/test/roles/anarchy_test_simple/templates/governor.yaml.j2
@@ -63,7 +63,7 @@ spec:
           "module is required" in r_mysql_info.msg
 
     callback_test:
-      explicitCompletion: true
+      finishOnSuccessfulRun: false
       tasks:
       - name: Print message
         debug:
@@ -73,7 +73,25 @@ spec:
         done:
           tasks:
           - name: Explicitly complete action
-            anarchy_complete_action: {}
+            anarchy_finish_action: {}
+
+    continuation_test:
+      tasks:
+      - name: Print message
+        debug:
+          msg: In continuation test
+      - name: Manage continuation
+        when: not continued | default(false)
+        block:
+        - name: Record change
+          anarchy_subject_update:
+            skip_update_processing: true
+            spec:
+              vars:
+                continued: true
+        - name: Schedule continution
+          anarchy_continue_action:
+            after: 30s
 
     destroy:
       tasks:

--- a/test/server/app.py
+++ b/test/server/app.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import base64
-import datetime
 import flask
 import gevent.pywsgi
 import json
@@ -17,9 +16,15 @@ import threading
 import time
 import yaml
 
+from copy import deepcopy
+from datetime import datetime, timedelta
+
 api = flask.Flask('rest')
 callbacks = {}
 domain = os.environ.get('ANARCHY_DOMAIN', 'anarchy.gpte.redhat.com')
+
+callback_url = None
+callback_token = None
 
 def init():
     global logger
@@ -64,65 +69,191 @@ def callback_loop():
             del callbacks[key]
         time.sleep(1)
 
-@api.route('/api/v2/job_templates/job-runner/launch/', methods=['POST'])
-def launch():
-    logger.info("Call to job job-runner launch")
+@api.route('/api/v2/tokens/', methods=['POST'])
+def api_v2_tokens_post():
+    return flask.jsonify({
+        "application": 1,
+        "created": datetime.utcnow().isoformat() + 'Z',
+        "expires": (datetime.utcnow() + timedelta(days=1)).isoformat() + 'Z',
+        "id": 11111111,
+        "token": "s3cr3tT0k3n"
+    }), 201
 
-    try:
-        assert flask.request.json, \
-            'no json data provided'
-        extra_vars = flask.request.json.get('extra_vars', None)
-        assert extra_vars, 'extra_vars not provided'
-        job_vars = extra_vars.get('job_vars', None)
-        assert job_vars, 'job_vars not provided in extra_vars'
-        job_meta = job_vars.get('__meta__', None)
-        assert job_meta, '__meta__ not provided in extra_vars.job_vars'
-        callback = job_meta.get('callback', None)
-        assert callback, 'callback not provided in extra_vars.job_vars.__meta__'
-        callback_token = callback.get('token', None)
-        callback_url = callback.get('url', None)
-        assert callback_token, 'callback_token not provided in extra_vars.job_vars.__meta__.callback'
-        assert callback_url, 'callback_url not provided in extra_vars.job_vars.__meta__.callback'
-        deployer = job_meta.get('deployer', None)
-        assert deployer, 'deployer not provided in extra_vars.job_vars.__meta__'
-        deployer_entry_point = deployer.get('entry_point', None)
-        assert deployer_entry_point, 'entry_point not provided in extra_vars.job_vars.__meta__.deployer'
-        tower = job_meta.get('tower', None)
-        assert tower, 'tower not provided in extra_vars.job_vars.__meta__'
-        tower_action = tower.get('action', None)
-        assert tower_action, 'action not provided in extra_vars.job_vars.__meta__.tower'
-        aws_access_key_id = job_vars.get('aws_access_key_id', None)
-        assert aws_access_key_id, 'aws_access_key_id not provided in extra_vars.job_vars'
-        assert aws_access_key_id == 'th3k3y', 'aws_access_key_id not correct'
-        aws_secret_access_key = job_vars.get('aws_secret_access_key', None)
-        assert aws_secret_access_key, 'aws_secret_access_key not provided in extra_vars.job_vars'
-        assert aws_secret_access_key == 'th34cc355', 'aws_secret_access_key not correct'
-    except Exception as e:
-        logger.exception("Invalid parameters passed to job-runner launch: " + str(e))
-        flask.abort(400)
+@api.route('/api/v2/tokens/<string:token_id>/', methods=['DELETE'])
+def api_v2_tokens_delete(token_id):
+    return flask.jsonify({}), 204
 
+@api.route('/api/v2/organizations/', methods=['GET'])
+def api_v2_organizations_get():
+    name = flask.request.args.get('name', 'default')
+    return flask.jsonify({
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [{
+            "created": datetime.utcnow().isoformat() + 'Z',
+            "id": 1,
+            "description": name,
+            "max_hosts": 0,
+            "name": name,
+            "type": "organization",
+            "url": "/api/v2/organizations/1/",
+        }]
+    }), 200
+
+@api.route('/api/v2/organizations/<string:org_id>/', methods=['PATCH'])
+def api_v2_organizations_patch(org_id):
+    return flask.jsonify({
+        "created": datetime.utcnow().isoformat() + 'Z',
+        "id": org_id,
+        "description": "default",
+        "max_hosts": 0,
+        "name": "default",
+        "type": "organization",
+        "url": "/api/v2/organizations/1/",
+    }), 200
+
+@api.route('/api/v2/inventories/', methods=['GET'])
+def api_v2_inventories_get():
+    org_id = flask.request.args.get('organization')
+    name = flask.request.args.get('name', 'default default')
+    return flask.jsonify({
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [{
+            "created": datetime.utcnow().isoformat() + 'Z',
+            "description": "",
+            "host_filter": None,
+            "id": 1,
+            "kind": "",
+            "name": name,
+            "organization": org_id,
+            "type": "inventory",
+            "url": "/api/v2/inventories/1/",
+        }]
+    }), 200
+
+@api.route('/api/v2/inventories/<string:inventory_id>/', methods=['PATCH'])
+def api_v2_inventories_patch(inventory_id):
+    return flask.jsonify({
+        "created": datetime.utcnow().isoformat() + 'Z',
+        "description": "",
+        "host_filter": None,
+        "id": inventory_id,
+        "kind": "",
+        "name": "default default",
+        "organization": 1,
+        "type": "inventory",
+        "url": "/api/v2/inventories/1/",
+    }), 200
+
+@api.route('/api/v2/projects/', methods=['GET'])
+def api_v2_projects_get():
+    org_id = flask.request.args.get('organization')
+    name = flask.request.args.get('name', 'default default')
+    return flask.jsonify({
+        "count": 1,
+        "next": None,
+        "previous": None,
+        "results": [{
+            "created": datetime.utcnow().isoformat() + 'Z',
+            "custom_virtualenv": None,
+            "id": 1,
+            "name": name,
+            "organization": org_id,
+            "scm_branch": "development",
+            "scm_clean": False,
+            "scm_delete_on_update": False,
+            "scm_refspec": "",
+            "scm_type": "git",
+            "scm_url": "https://github.com/redhat-cop/agnosticd.git",
+            "scm_update_cache_timeout": 30,
+            "scm_update_on_launch": True,
+            "summary_fields": {},
+            "timeout": 0,
+            "type": "project",
+            "url": "/api/v2/projects/1/",
+        }]
+    }), 200
+
+@api.route('/api/v2/projects/<string:project_id>/', methods=['PATCH'])
+def api_v2_projects_patch(project_id):
+    ret = deepcopy(flask.request.json)
+    ret['created']: datetime.utcnow().isoformat() + 'Z'
+    ret['modified']: datetime.utcnow().isoformat() + 'Z'
+    ret['id'] = project_id
+    ret['summary_fields'] = dict()
+    ret['url'] = '/api/v2/projects/{}/'.format(project_id)
+    return flask.jsonify(ret), 200
+
+@api.route('/api/v2/job_templates/', methods=['GET'])
+def api_v2_job_templates_get():
+    name = flask.request.args.get('name')
+    results = []
+    if name:
+        results.append({
+            "ask_inventory_on_launch": True,
+            "id": 1,
+            "name": name,
+            "related": {
+                "launch": "/api/v2/job_templates/1/launch/",
+            },
+            "type": "job_template",
+            "url": "/api/v2/job_templates/1/",
+        })
+    return flask.jsonify({
+        "count": len(results),
+        "next": None,
+        "previous": None,
+        "results": results,
+    }), 200
+
+@api.route('/api/v2/job_templates/<string:job_template_id>/', methods=['PATCH'])
+def api_v2_job_templates_patch(job_template_id):
+    global callback_url, callback_token
+    extra_vars = flask.request.json.get('extra_vars')
+    if not extra_vars:
+        flask.abort(400, description='extra_vars not passed')
+    extra_vars = json.loads(extra_vars)
+    __meta__ = extra_vars.get('__meta__')
+    if not __meta__:
+        flask.abort(400, description='__meta__ not in extra_vars')
+    callback = __meta__.get('callback')
+    if not callback:
+        flask.abort(400, description='callback not in extra_vars.__meta__')
+    callback_token = callback.get('token')
+    if not callback_token:
+        flask.abort(400, description='token not in extra_vars.__meta__.callback')
+    callback_url = callback.get('url')
+    if not callback_url:
+        flask.abort(400, description='url not in extra_vars.__meta__.callback')
+    ret = deepcopy(flask.request.json)
+    ret['created']: datetime.utcnow().isoformat() + 'Z'
+    ret['id'] = job_template_id
+    ret['modified'] = datetime.utcnow().isoformat() + 'Z'
+    ret['type'] = 'job_template'
+    ret['url'] = '/api/v2/job_templates/{}/'.format(job_template_id)
     logger.info("Callback URL %s", callback_url)
+    return flask.jsonify(ret), 200
+
+@api.route('/api/v2/job_templates/<string:job_template_id>/launch/', methods=['POST'])
+def api_v2_job_templates_job_runner_launch_post(job_template_id):
+    global callback_url, callback_token
 
     job_id = random.randint(1,10000000)
-    schedule_callback(
-        after=time.time() + 1,
-        event='started',
-        job_id=job_id,
-        msg='started ' + tower_action,
-        token=callback_token,
-        url=callback_url
-    )
     schedule_callback(
         after=time.time() + 10,
         event='complete',
         job_id=job_id,
-        msg='completed ' + tower_action,
+        msg='completed',
         token=callback_token,
         url=callback_url
     )
     return flask.jsonify({
         "id": job_id,
-        "job": job_id
+        "job": job_id,
+        "status": '',
     }), 201
 
 @api.route('/runner/<string:runner_queue_name>/<string:runner_name>', methods=['GET', 'POST'])

--- a/test/server/app.py
+++ b/test/server/app.py
@@ -259,17 +259,42 @@ def api_v2_job_templates_job_runner_launch_post(job_template_id):
         "status": '',
     }), 201
 
-@api.route('/api/v2/jobs/<string:job_id>/launch/', methods=['GET'])
-def api_v2_jobs_get(job_id):
+def job_data(job_id):
+    data = {
+        "status": "running",
+        "related": {
+            "cancel": "/api/v2/jobs/{}/cancel/".format(job_id),
+        },
+        "type": "job_template",
+        "url": "/api/v2/jobs/{}/".format(job_id),
+    }
     if simulate_job_result == 'successful':
-        return flask.jsonify({
-            "status": "running",
-        }), 200
+        data['status'] = 'successful'
     else:
-        return flask.jsonify({
-            "status": simulate_job_result,
-        }), 200
+        data['status'] = simulate_job_result
+    return data
 
+@api.route('/api/v2/jobs/', methods=['GET'])
+def api_v2_jobs_get():
+    job_id = flask.request.args['id']
+    return flask.jsonify({
+        "count": 1,
+        "results": [ job_data(job_id) ]
+    }), 200
+
+@api.route('/api/v2/jobs/<string:job_id>/', methods=['GET'])
+def api_v2_jobs_id_get(job_id):
+    return flask.jsonify(job_data(job_id))
+
+@api.route('/api/v2/jobs/<string:job_id>/cancel/', methods=['GET'])
+def api_v2_jobs_cancel_get(job_id):
+    return flask.jsonify({
+        "can_cancel": True
+    }), 200
+
+@api.route('/api/v2/jobs/<string:job_id>/cancel/', methods=['POST'])
+def api_v2_jobs_cancel_post(job_id):
+    return flask.jsonify({}), 202
 
 @api.route('/runner/<string:runner_queue_name>/<string:runner_name>', methods=['GET', 'POST'])
 def runner_get(runner_queue_name, runner_name):


### PR DESCRIPTION
This PR changes Anarchy action scheduling to restrict AnarchyAction execution such that only one AnarchyAction will run at a time for an AnarchyRun. The next AnarchyAction will only get an AnarchyRun created after the previous finishes.

This PR also adds a number of new tests and test capabilities to validate functionality of the babylon_anarchy_governor including handling failed provisions.