### PR TITLE
Add update exposing previous state

### DIFF
--- a/operator/operator.py
+++ b/operator/operator.py
@@ -96,14 +96,14 @@ def handle_subject_update(body, old, new, **_):
     try:
         subject = AnarchySubject(body)
         if old['spec'] != new['spec']:
-            subject.handle_spec_update(runtime)
+            subject.handle_spec_update(old, runtime)
     except AssertionError as e:
         operator_logger.warning('AnarchySubject %s invalid: %s', body['metadata']['name'], e)
 
 @kopf.on.event(runtime.operator_domain, runtime.api_version, 'anarchysubjects')
 def handle_subject_event(event, logger, **_):
     '''
-    Anarchy uses on.event instead of on.delete because Anarchy needs custom
+    Anarchy uses on.event instead of on.delete because Anarchy supports custom
     for removing finalizers. The finalizer will be removed immediately if the
     AnarchyGovernor does not have a delete subject event handler. If there is
     a delete subject event handler then it is up to the governor logic to remove

--- a/test/roles/anarchy_test_babylon/tasks/test.yaml
+++ b/test/roles/anarchy_test_babylon/tasks/test.yaml
@@ -176,3 +176,85 @@
     until: r_get_test_babylon_2_subject is success
     retries: 20
     delay: 5
+
+- name: Create AnarchySubject test-babylon-3
+  k8s:
+    apply: true
+    state: present
+    definition: "{{ lookup('template', 'subject.yaml.j2') | from_yaml }}"
+  vars:
+    _name: test-babylon-3
+    _vars:
+      desired_state: started
+      tower_job_check_interval: 10s
+
+- name: Wait for test-babylon-3 subject started
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    name: test-babylon-3
+    namespace: "{{ anarchy_namespace }}"
+  register: r_test_subject
+  until:
+  - r_test_subject.resources[0].metadata.labels.state | default('') == 'started'
+  - r_test_subject.resources[0].spec.vars.current_state | default('')  == 'started'
+  retries: 20
+  delay: 5
+
+- name: Update AnarchySubject test-babylon-3 to fail on destroy
+  k8s:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    name: test-babylon-3
+    namespace: "{{ anarchy_namespace }}"
+    definition:
+      spec:
+        vars:
+          job_vars:
+            simulate_job_result: failed
+
+- name: Delete test-babylon-3 subject
+  k8s:
+    state: absent
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    name: test-babylon-3
+    namespace: "{{ anarchy_namespace }}"
+
+- name: Wait for test-babylon-3 subject destroy-failed
+  k8s_info:
+    api_version: anarchy.gpte.redhat.com/v1
+    kind: AnarchySubject
+    name: test-babylon-3
+    namespace: "{{ anarchy_namespace }}"
+  register: r_test_subject
+  until:
+  - r_test_subject.resources[0].metadata.labels.state | default('') == 'destroy-failed'
+  - r_test_subject.resources[0].spec.vars.current_state | default('')  == 'destroy-failed'
+  retries: 20
+  delay: 5
+
+- when: anarchy_test_delete_subjects | bool
+  block:
+  - name: Update AnarchySubject to complete delete
+    k8s:
+      api_version: anarchy.gpte.redhat.com/v1
+      kind: AnarchySubject
+      name: test-babylon-3
+      namespace: "{{ anarchy_namespace }}"
+      definition:
+        spec:
+          vars:
+            force_delete: true
+
+  - name: Verify AnarchySubject delete for test-babylon-3
+    k8s_info:
+      api_version: anarchy.gpte.redhat.com/v1
+      kind: AnarchySubject
+      name: test-babylon-3
+      namespace: "{{ anarchy_namespace }}"
+    register: r_get_test_babylon_3_subject
+    failed_when: r_get_test_babylon_3_subject.resources | default([]) | length != 0
+    until: r_get_test_babylon_3_subject is success
+    retries: 20
+    delay: 5

--- a/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
+++ b/test/roles/anarchy_test_babylon/templates/governor.yaml.j2
@@ -47,6 +47,11 @@ spec:
     update:
       roles:
       - role: babylon_anarchy_governor
+      tasks:
+      - name: Force delete
+        when: force_delete | default(false) | bool
+        anarchy_subject_delete:
+          remove_finalizers: true
     delete:
       roles:
       - role: babylon_anarchy_governor

--- a/test/roles/anarchy_test_simple/tasks/test.yaml
+++ b/test/roles/anarchy_test_simple/tasks/test.yaml
@@ -166,6 +166,16 @@
       a_var_from_subject: 42
       a_var_subject_should_override: true
       anarchy_event_name: update
+      anarchy_subject_previous_state:
+        metadata:
+          labels:
+            anarchy.gpte.redhat.com/governor: test-simple
+            anarchy.gpte.redhat.com/test: simple
+        spec:
+          governor: test-simple
+          vars:
+            a_var_from_subject: 23
+            a_var_subject_should_override: true
 
 - name: Get AnarchyAction scheduled by AnarchyRun for update of test-simple-1
   k8s_info:


### PR DESCRIPTION
Update to anarchy subject now sets `anarchy_subject_previous_state`.

Closes #90 