### PR TITLE
Correct typo in Helm ingress template

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -9,7 +9,7 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ $name }}
-  namespace: {{ include "anarchy.namespapceName" . }}
+  namespace: {{ include "anarchy.namespaceName" . }}
   labels:
     {{- include "anarchy.labels" . | nindent 4 }}
   {{- with .Values.ingress.annotations }}


### PR DESCRIPTION
Corrects a small typo in the namespace parameter for the Helm chart ingress template.