### PR TITLE
Add supportedActions to AnarchySubject

### DIFF
--- a/helm/crds/anarchygovernors.yaml
+++ b/helm/crds/anarchygovernors.yaml
@@ -98,6 +98,10 @@ spec:
                 additionalProperties:
                   type: object
                   properties:
+                    description:
+                      description: >-
+                        Description of what this action does when run.
+                      type: string
                     finishOnSuccessfulRun:
                       description: >-
                         Flag to indicate whether this action should be marked as finished automatically

--- a/helm/crds/anarchysubjects.yaml
+++ b/helm/crds/anarchysubjects.yaml
@@ -172,3 +172,12 @@ spec:
                           type: string
                         uid:
                           type: string
+              supportedActions:
+                description: >-
+                  Actions supported by the governor for this subject.
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    description:
+                      type: string

--- a/operator/anarchygovernor.py
+++ b/operator/anarchygovernor.py
@@ -62,6 +62,10 @@ class AnarchyGovernor(object):
             return self.spec.get('callbackNameParameter', None)
 
         @property
+        def description(self):
+            return self.spec.get('description')
+
+        @property
         def finish_on_successful_run(self):
             """
             Boolean flag indicating whether actions using this action config are
@@ -305,6 +309,18 @@ class AnarchyGovernor(object):
     @property
     def resource_version(self):
         return self.metadata['resourceVersion']
+
+    @property
+    def supported_actions(self):
+        '''
+        Report supported actions for subjects.
+        '''
+        ret = {}
+        for name, action in self.actions.items():
+            ret[name] = {}
+            if action.description:
+                ret[name]['description'] = action.description
+        return ret
 
     @property
     def uid(self):

--- a/operator/anarchysubject.py
+++ b/operator/anarchysubject.py
@@ -356,6 +356,16 @@ class AnarchySubject(object):
         ).encode('utf-8')).digest()).decode('utf-8')
 
     @property
+    def supported_actions(self):
+        '''
+        Actions supported by governor for this subject.
+        '''
+        if self.status:
+            return self.status.get('supportedActions', {})
+        else:
+            return {}
+
+    @property
     def uid(self):
         return self.metadata['uid']
 
@@ -487,6 +497,19 @@ class AnarchySubject(object):
                         'labels': {
                             anarchy_runtime.governor_label: self.governor_name
                         }
+                    }
+                }
+            )
+            self.__init__(resource_object)
+
+        governor = self.get_governor()
+        if not self.supported_actions == governor.supported_actions:
+            resource_object = anarchy_runtime.custom_objects_api.patch_namespaced_custom_object_status(
+                anarchy_runtime.operator_domain, anarchy_runtime.api_version,
+                self.namespace, 'anarchysubjects', self.name,
+                {
+                    'status': {
+                        'supportedActions': governor.supported_actions
                     }
                 }
             )


### PR DESCRIPTION
This provides a means for automation tools to determine what actions are supported such as the Babylon UI showing start/stop/status functionality based on what actions are supported on the AnarchySubject.