### PR TITLE
fix: add retry with exp backoff to action plugins

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM quay.io/rhpds/python-kopf-s2i:v1.38
+FROM quay.io/rhpds/python-kopf-s2i:v1.44
 
 USER root
 

--- a/anarchy-runner/ansible-runner/project/action_plugins/anarchy_schedule_action.py
+++ b/anarchy-runner/ansible-runner/project/action_plugins/anarchy_schedule_action.py
@@ -6,9 +6,17 @@
 from datetime import datetime, timedelta
 import os
 import re
+import time
 import requests
 
 from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+display = Display()
+
+RETRY_COUNT = 3
+RETRY_DELAY = 5
+RETRY_BACKOFF = 2
 
 datetime_re = re.compile(r'^\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ$')
 
@@ -59,15 +67,33 @@ class ActionModule(ActionBase):
                 result['message'] = 'Invalid value for `after`: {}'.format(after)
                 return result
 
-        response = requests.post(
-            anarchy_url + '/run/subject/' + anarchy_subject_name + '/actions',
-            headers={'Authorization': 'Bearer {}:{}:{}'.format(
-                anarchy_runner_name, anarchy_run_pod_name, anarchy_runner_token
-            )},
-            json=dict(action=action, after=after, cancel=cancel, vars=vars)
+        url = anarchy_url + '/run/subject/' + anarchy_subject_name + '/actions'
+        headers = {'Authorization': 'Bearer {}:{}:{}'.format(
+            anarchy_runner_name, anarchy_run_pod_name, anarchy_runner_token
+        )}
+        payload = dict(action=action, after=after, cancel=cancel, vars=vars)
+
+        last_exception = None
+        for attempt in range(1, RETRY_COUNT + 1):
+            try:
+                response = requests.post(url, headers=headers, json=payload)
+                response.raise_for_status()
+                response_json = response.json()
+                result['action'] = response_json['result']
+                result['failed'] = not response_json['success']
+                return result
+            except (requests.exceptions.RequestException, ValueError, KeyError) as e:
+                last_exception = e
+                display.warning(
+                    "anarchy_schedule_action {}: attempt {}/{} failed: {}".format(
+                        anarchy_subject_name, attempt, RETRY_COUNT, str(e)
+                    )
+                )
+                if attempt < RETRY_COUNT:
+                    time.sleep(RETRY_DELAY * (RETRY_BACKOFF ** (attempt - 1)))
+
+        result['failed'] = True
+        result['msg'] = "anarchy_schedule_action failed after {} attempts: {}".format(
+            RETRY_COUNT, str(last_exception)
         )
-
-        result['action'] = response.json()['result']
-        result['failed'] = not response.json()['success']
-
         return result

--- a/anarchy-runner/ansible-runner/project/action_plugins/anarchy_subject_update.py
+++ b/anarchy-runner/ansible-runner/project/action_plugins/anarchy_subject_update.py
@@ -5,10 +5,18 @@
 
 import os
 import re
+import time
 import requests
 
 from ansible.plugins.action import ActionBase
 from ansible.module_utils.parsing.convert_bool import boolean
+from ansible.utils.display import Display
+
+display = Display()
+
+RETRY_COUNT = 3
+RETRY_DELAY = 5
+RETRY_BACKOFF = 2
 
 class ActionModule(ActionBase):
     def run(self, tmp=None, task_vars=None, **_):
@@ -30,14 +38,33 @@ class ActionModule(ActionBase):
         if boolean(module_args.get('skip_update_processing', False), strict=False):
             patch['skip_update_processing'] = True
 
-        response = requests.patch(
-            anarchy_url + '/run/subject/' + anarchy_subject_name,
-            headers={'Authorization': 'Bearer {}:{}:{}'.format(
-                anarchy_runner_name, anarchy_run_pod_name, anarchy_runner_token
-            )},
-            json=dict(patch=patch)
-        )
-        result['subject'] = response.json()['result']
-        result['failed'] = not response.json()['success']
+        url = anarchy_url + '/run/subject/' + anarchy_subject_name
+        headers = {'Authorization': 'Bearer {}:{}:{}'.format(
+            anarchy_runner_name, anarchy_run_pod_name, anarchy_runner_token
+        )}
+        payload = dict(patch=patch)
 
+        last_exception = None
+        for attempt in range(1, RETRY_COUNT + 1):
+            try:
+                response = requests.patch(url, headers=headers, json=payload)
+                response.raise_for_status()
+                response_json = response.json()
+                result['subject'] = response_json['result']
+                result['failed'] = not response_json['success']
+                return result
+            except (requests.exceptions.RequestException, ValueError, KeyError) as e:
+                last_exception = e
+                display.warning(
+                    "anarchy_subject_update {}: attempt {}/{} failed: {}".format(
+                        anarchy_subject_name, attempt, RETRY_COUNT, str(e)
+                    )
+                )
+                if attempt < RETRY_COUNT:
+                    time.sleep(RETRY_DELAY * (RETRY_BACKOFF ** (attempt - 1)))
+
+        result['failed'] = True
+        result['msg'] = "anarchy_subject_update failed after {} attempts: {}".format(
+            RETRY_COUNT, str(last_exception)
+        )
         return result

--- a/api/anarchyaction.py
+++ b/api/anarchyaction.py
@@ -195,4 +195,4 @@ class AnarchyAction(VarSecretMixin, AnarchyObject):
                 }
             }
         )
-        logging.info("Created {anarchy_run} to process {self} {callback_name} callback")
+        logging.info("Created %s to process %s %s callback", anarchy_run, self, callback_name)

--- a/api/app.py
+++ b/api/app.py
@@ -154,7 +154,7 @@ async def post_run(request):
         anarchy_runner_pod.consecutive_failure_count += 1
         await anarchy_run.set_runner_state_failed(result)
     elif result_status == 'successful':
-        logging.info(f"{anarchy_runner_pod} posted successful result for {anarchy_run}")
+        logging.info("%s posted successful result for %s", anarchy_runner_pod, anarchy_run)
         anarchy_runner_pod.consecutive_failure_count = 0
         await anarchy_run.set_runner_state_successful(result)
     else:

--- a/operator/anarchysubject.py
+++ b/operator/anarchysubject.py
@@ -136,26 +136,67 @@ class AnarchySubject(AnarchyCachedKopfObject):
             }])
 
     async def add_run_to_status(self, anarchy_run):
-        if self.has_run_in_status(anarchy_run):
-            return
-        if not 'runs' in self.status:
-            await self.json_patch_status([{
-                "op": "add",
-                "path": f"/status/runs",
-                "value": {"active": [anarchy_run.as_reference()]},
-            }])
-        elif not 'active' in self.status['runs']:
-            await self.json_patch_status([{
-                "op": "add",
-                "path": f"/status/runs/active",
-                "value": [anarchy_run.as_reference()],
-            }])
-        else:
-            await self.json_patch_status([{
-                "op": "add",
-                "path": f"/status/runs/active/-",
-                "value": anarchy_run.as_reference(),
-            }])
+        while True:
+            try:
+                if self.has_run_in_status(anarchy_run):
+                    return
+                add_as_active = True
+                if not 'runs' in self.status:
+                    patch = [{
+                        "op": "test",
+                        "path": "/status/runs",
+                        "value": None,
+                    }, {
+                        "op": "add",
+                        "path": f"/status/runs",
+                        "value": {"active": [anarchy_run.as_reference()]},
+                    }]
+                elif not 'active' in self.status['runs']:
+                    patch = [{
+                        "op": "test",
+                        "path": "/status/runs/active",
+                        "value": None,
+                    }, {
+                        "op": "add",
+                        "path": f"/status/runs/active",
+                        "value": [anarchy_run.as_reference()],
+                    }]
+                elif len(self.status['runs']['active']) == 0:
+                    patch = [{
+                        "op": "test",
+                        "path": "/status/runs/active",
+                        "value": [],
+                    }, {
+                        "op": "add",
+                        "path": f"/status/runs/active/-",
+                        "value": anarchy_run.as_reference(),
+                    }]
+                else:
+                    add_as_active = False
+                    patch = [{
+                        "op": "test",
+                        "path": "/status/runs/active/0/name",
+                        "value": self.status['runs']['active'][0]['name'],
+                    }, {
+                        "op": "add",
+                        "path": f"/status/runs/active/-",
+                        "value": anarchy_run.as_reference(),
+                    }]
+                await self.json_patch_status(patch)
+                if add_as_active:
+                    logging.info("Added %s as active run for %s", anarchy_run, self)
+                else:
+                    logging.info("Added %s as queued run for %s", anarchy_run, self)
+                break
+            except kubernetes_asyncio.client.rest.ApiException as e:
+                if e.status == 422:
+                    # Refresh definition and retry
+                    await self.refresh()
+                elif e.status == 404:
+                    logging.warning(f"%s not found while attempting to add %s to status", self, anarchy_run)
+                    break
+                else:
+                    raise
 
     async def check_complete_delete(self):
         """
@@ -582,15 +623,21 @@ class AnarchySubject(AnarchyCachedKopfObject):
             }])
 
     async def remove_run_from_status(self, anarchy_run):
+        if not self.has_run_in_status(anarchy_run):
+            await self.refresh()
         if self.has_run_in_status(anarchy_run):
             try:
                 if anarchy_run.name == self.active_run_name:
+                    logging.info("Removing active %s from %s status", anarchy_run, self)
                     await self.remove_active_run_from_status(anarchy_run)
                 else:
+                    logging.info("Removing queued %s from %s status", anarchy_run, self)
                     await self.remove_queued_run_from_status(anarchy_run)
             except kubernetes_asyncio.client.rest.ApiException as e:
                 if e.status != 404:
                     raise
+        else:
+            logging.warning("%s was not found in %s status", anarchy_run, self)
 
     async def remove_active_run_from_status(self, anarchy_run):
         try:

--- a/operator/anarchysubject.py
+++ b/operator/anarchysubject.py
@@ -136,7 +136,11 @@ class AnarchySubject(AnarchyCachedKopfObject):
             }])
 
     async def add_run_to_status(self, anarchy_run):
-        while True:
+        """Add AnarchyRun reference to AnarchySubject status"""
+        # Attempt to add AnarchyRun to status with retries in case the state of
+        # the AnarchySubject in memory is out of sync with etcd.
+        max_retries = 10
+        for attempt in range(max_retries):
             try:
                 if self.has_run_in_status(anarchy_run):
                     return
@@ -187,16 +191,20 @@ class AnarchySubject(AnarchyCachedKopfObject):
                     logging.info("Added %s as active run for %s", anarchy_run, self)
                 else:
                     logging.info("Added %s as queued run for %s", anarchy_run, self)
-                break
+                return
             except kubernetes_asyncio.client.rest.ApiException as e:
                 if e.status == 422:
-                    # Refresh definition and retry
+                    # Refresh AnachySubject state and retry
                     await self.refresh()
                 elif e.status == 404:
-                    logging.warning(f"%s not found while attempting to add %s to status", self, anarchy_run)
-                    break
+                    logging.warning("%s not found while attempting to add %s to status", self, anarchy_run)
+                    return
                 else:
                     raise
+        raise kopf.TemporaryError(
+            "Failed to add %s to %s status after %s retries",
+            anarchy_run, self, max_retries,
+        )
 
     async def check_complete_delete(self):
         """
@@ -587,20 +595,33 @@ class AnarchySubject(AnarchyCachedKopfObject):
             await self.json_patch_status(patch)
 
     async def remove_action_from_status(self, anarchy_action):
-        while True:
+        """Remove AnarchyAction reference from AnarchySubject status"""
+        # Remove reference to AnarchyAction with retries in case the state of
+        # the AnarchySubject in memory is out of sync with etcd.
+        max_retries = 10
+        for attempt in range(max_retries):
             try:
                 patch = []
                 if anarchy_action.name == self.active_action_name:
-                    patch.append({
+                    patch.extend([{
+                        "op": "test",
+                        "path": "/status/activeAction/name",
+                        "value": anarchy_action.name,
+                    }, {
                         "op": "remove",
                         "path": "/status/activeAction",
-                    })
+                    }])
                 else:
                     for i, item in enumerate(self.pending_actions):
                         if item['name'] == anarchy_action.name:
                             patch.insert(0, {
                                 "op": "remove",
                                 "path": f"/status/pendingActions/{i}",
+                            })
+                            patch.insert(0, {
+                                "op": "test",
+                                "path": "f/status/pendingActions/{i}/name",
+                                "value": anarchy_action.name
                             })
                 if patch:
                     await self.json_patch_status(patch)
@@ -611,6 +632,10 @@ class AnarchySubject(AnarchyCachedKopfObject):
                 elif e.status != 404:
                     logging.error(f"Failed to apply {patch} to {self}")
                     raise
+        raise kopf.TemporaryError(
+            "Failed to remove %s from %s status after %s retries",
+            anarchy_action, self, max_retries,
+        )
 
     async def remove_anarchy_finalizers(self):
         """
@@ -700,12 +725,16 @@ class AnarchySubject(AnarchyCachedKopfObject):
         })
 
     async def set_active_run_pending(self):
+        """Trigger management of top active AnarchyRun to trigger it switching
+        to pending state.
+
+        If deletion has been initiated then any active AnarchyRuns that are not
+        related to delete handling are removed from active status first."""
         while True:
             if not self.active_run_name:
                 return
             try:
                 anarchy_run = await anarchyrun.AnarchyRun.get(self.active_run_name)
-
                 if self.is_deleting \
                 and not anarchy_run.is_delete_handler:
                     await anarchy_run.set_to_canceled()

--- a/test/roles/anarchy_test_simple/tasks/test-00.yaml
+++ b/test/roles/anarchy_test_simple/tasks/test-00.yaml
@@ -90,7 +90,7 @@
     - _run.spec.handler.name == 'create'
     - _run.spec.handler.type == 'subjectEvent'
     - _run.spec.subject.name == 'test-simple-00-a'
-    - _run.spec.subject.vars == {"n": 1}
+    - '_run.spec.subject.vars == {"n": 1}'
 
 - name: Wait for AnarchyRun for create of AnarchySubject test-simple-00-a successful
   kubernetes.core.k8s_info:

--- a/test/roles/anarchy_test_simple/tasks/test-02.yaml
+++ b/test/roles/anarchy_test_simple/tasks/test-02.yaml
@@ -153,7 +153,7 @@
     - _run.spec.governor.name == 'test-simple-02'
     - _run.spec.handler.type == 'action'
     - _run.spec.subject.name == 'test-simple-02-a'
-    - _run.spec.subject.vars == {"n": 1}
+    - '_run.spec.subject.vars == {"n": 1}'
 
 - name: Wait for AnarchyRun for AnarcyhAction to be successful for test-simple-02-a
   kubernetes.core.k8s_info:

--- a/test/roles/anarchy_test_simple/tasks/test.yaml
+++ b/test/roles/anarchy_test_simple/tasks/test.yaml
@@ -632,7 +632,8 @@
     _subject: "{{ r_get_test_simple_1.resources[0] | default({}) }}"
   failed_when: >-
     _subject.status.runStatus | default('') != 'failed' or
-    _subject.status.runStatusMessage | default('') != 'Failed run as requested'
+    _subject.status.runStatusMessage | default('') != 'localhost failed fail, Fail run: Failed run as requested'
+
   until: r_get_test_simple_1 is success
   retries: 10
   delay: 5


### PR DESCRIPTION
The anarchy_subject_update and anarchy_schedule_action plugins call response.json() without error handling. When the anarchy API returns an empty body or a non-JSON response due to transient issues, `json.loads("")` raises JSONDecodeError: "Expecting value: line 1 column 1 (char 0)". This causes intermittent provision failures that succeed on retry.

- Add retry loop (3 attempts, exponential backoff: 5s, 10s)
- Add response.raise_for_status() before parsing JSON
- Catch RequestException, ValueError, and KeyError
- Log warnings on each failed attempt via ansible display
- Return actionable error message when all retries exhausted