### PR TITLE
Add Prometheus metrics support using aioprometheus

### DIFF
--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -1,0 +1,1612 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.4.1"
+    },
+    {
+      "type": "panel",
+      "id": "marcusolsson-treemap-panel",
+      "name": "Treemap",
+      "version": "2.0.1"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      },
+      {
+        "datasource": {
+          "type": "datasource",
+          "uid": "grafana"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "red",
+        "name": "Release",
+        "target": {
+          "limit": 100,
+          "matchAny": true,
+          "refId": "Anno",
+          "tags": [
+            "anarchy"
+          ],
+          "type": "tags"
+        }
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 27,
+      "panels": [],
+      "title": "Anarchy Process",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the average duration of process executions for each method, grouped by method and app over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\"}[5m])) by (app)\n/\nsum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\"}[5m])) by (app)",
+          "instant": false,
+          "legendFormat": "{{app}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Duration by App $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the 95th percentile of execution times, providing insights into the longest durations affecting most requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\"}[5m])) by (le, app))",
+          "instant": false,
+          "legendFormat": "{{app}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "95th Percentile (P95) Execution Time by App - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the total time spent on process executions for each method, aggregated over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\"}[5m])) by (app)",
+          "instant": false,
+          "legendFormat": "{{app}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Execution Time by App - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 30,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max",
+            "mean"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\"}[5m])) by (app)",
+          "instant": false,
+          "legendFormat": "{{app}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Number of Executions by App - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 38,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Max",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\"}[5m])) by (app)",
+          "instant": false,
+          "legendFormat": "{{app}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Number of Error Executions by App - $app",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 40
+      },
+      "id": 32,
+      "panels": [],
+      "title": "Operator Process Detail",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the average duration of process executions for each method, grouped by method and app over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "fieldMinMax": false,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 33,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "maxHeight": 20,
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\"}[5m])) by (app, method)\n/\nsum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\"}[5m])) by (app, method)",
+          "instant": false,
+          "legendFormat": "{{app}} {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Average Duration by Method - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the 95th percentile of execution times, providing insights into the longest durations affecting most requests.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 34,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\" }[5m])) by (le, app, method))",
+          "instant": false,
+          "legendFormat": "{{app}} {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "95th Percentile (P95) Execution Time by Method - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the total time spent on process executions for each method, aggregated over time.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 52
+      },
+      "id": 36,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\"}[5m])) by (app, method)",
+          "instant": false,
+          "legendFormat": "{{app}} {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Execution Time by Method - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 2,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 52
+      },
+      "id": 35,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\"}[5m])) by (app, method)",
+          "instant": false,
+          "legendFormat": "{{app}} {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Number of Executions by Method - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "noValue": "0",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 12,
+        "x": 0,
+        "y": 64
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\"}[$interval])) by (app, method)",
+          "instant": false,
+          "legendFormat": "{{app}} {{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total Number of Error Executions by Method - $app",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Treemap visualization displaying the total execution across various apps and their respective methods. Each block represents a method within an app, sized by the total execution  over the selected time range. This helps in identifying which methods contribute most significantly to the overall.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "fieldMinMax": false,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 1500
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 13,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "id": 42,
+      "options": {
+        "groupByField": "app",
+        "labelFields": [
+          "method"
+        ],
+        "textField": "method",
+        "tiling": "treemapSquarify"
+      },
+      "pluginVersion": "2.0.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\"}[5m])) by (app, method)",
+          "format": "table",
+          "hide": false,
+          "instant": false,
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Execution Breakdown by App and Method",
+      "type": "marcusolsson-treemap-panel"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 24,
+        "x": 0,
+        "y": 88
+      },
+      "id": 75,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (app, method, status) ( increase(anarchy_process_time_seconds_count{status=\"error\"}[1h]) )",
+          "instant": false,
+          "legendFormat": "{{app}}.{{method}} - {{status}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Error Rate by App.Method",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Shows the percentage of errors per application  and method over the last 24 hours. Calculated as 100 * increase(error) / increase(error + success) from the reporting_process_time_seconds_count counter. Uses an instant query; each gauge represents one app. Sorted descending. Suggested thresholds: 1% (warn), 5% (critical).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 100,
+          "min": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "#EAB839",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 14,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "id": 74,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sort_desc(\n  topk(\n    10,\n    100 *\n    sum by (app, method) ( increase(anarchy_process_time_seconds_count{status=\"error\"}[1h]) )\n    /\n    clamp_min(\n      sum by (app, method) ( increase(anarchy_process_time_seconds_count{status=~\"error|success\"}[1h]) ),\n      1\n    )\n  )\n)",
+          "instant": false,
+          "legendFormat": "{{app}}.{{method}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "1h",
+      "title": "Error Rate by App.Method - Last 24h",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Shows the percentage of errors per application over the last 24 hours. Calculated as 100 * increase(error) / increase(error + success) from the reporting_process_time_seconds_count counter. Uses an instant query; each gauge represents one app. Sorted descending. Suggested thresholds: 1% (warn), 5% (critical).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "decimals": 2,
+          "mappings": [],
+          "max": 100,
+          "min": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "#EAB839",
+                "value": 3
+              },
+              {
+                "color": "red",
+                "value": 5
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 15,
+        "w": 24,
+        "x": 0,
+        "y": 113
+      },
+      "id": 73,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "sizing": "auto"
+      },
+      "pluginVersion": "10.4.1",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "sort_desc(\n  100 *\n  sum by (app) ( increase(anarchy_process_time_seconds_count{status=\"error\"}[1h]) )\n  /\n  clamp_min(\n    sum by (app) ( increase(anarchy_process_time_seconds_count{status=~\"error|success\"}[1h]) ),\n    1\n  )\n)",
+          "instant": true,
+          "legendFormat": "{{app}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "timeFrom": "1h",
+      "title": "Error Rate by App - Last 24h",
+      "type": "gauge"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Datasource",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(anarchy_process_time_seconds_bucket,app)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Operator Class",
+        "multi": true,
+        "name": "app",
+        "options": [],
+        "query": {
+          "qryType": 1,
+          "query": "label_values(anarchy_process_time_seconds_bucket,app)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "selected": false,
+          "text": "5m",
+          "value": "5m"
+        },
+        "hide": 0,
+        "label": "Interval",
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": true,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "1m,5m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Anarchy Observability",
+  "uid": "anarchy-observability",
+  "version": 1,
+  "weekStart": ""
+}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -31,6 +31,10 @@ spec:
         env:
         - name: ANARCHY_SERVICE
           value: {{ include "anarchy.name" $ }}
+        {{- if $.Values.metrics.enabled }}
+        - name: METRICS_ENABLED
+          value: "true"
+        {{- end }}
         {{- range $k, $v := $namespace.envVars | default $.Values.envVars }}
         - name: {{ $k | quote }}
           value: {{ $v | quote }}
@@ -41,6 +45,11 @@ spec:
         image: {{ $.Values.image.repository }}:v{{ $.Chart.AppVersion }}
         {{- end }}
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
+        ports:
+        - name: kopf
+          containerPort: 8080
+        - name: metrics
+          containerPort: 9091
         livenessProbe:
           httpGet:
             path: /healthz

--- a/helm/templates/metrics-credentials.yaml
+++ b/helm/templates/metrics-credentials.yaml
@@ -1,0 +1,17 @@
+{{- if (and .Values.deploy .Values.metrics.enabled) -}}
+apiVersion: secretgenerator.mittwald.de/v1alpha1
+kind: StringSecret
+metadata:
+  name: {{ include "anarchy.name" . }}-metrics-credentials
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "anarchy.labels" . | nindent 4 }}
+spec:
+  forceRegenerate: false
+  data:
+    metrics_username: {{ .Values.metrics.username }}
+  fields:
+  - fieldName: metrics_password
+    encoding: "hex"
+    length: "32"
+{{- end }}

--- a/helm/templates/metrics-service.yaml
+++ b/helm/templates/metrics-service.yaml
@@ -1,0 +1,19 @@
+{{- if (and .Values.deploy .Values.metrics.enabled) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "anarchy.name" . }}-metrics
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "anarchy.labels" . | nindent 4 }}
+    app.kubernetes.io/component: operator
+spec:
+  type: ClusterIP
+  ports:
+  - name: metrics
+    protocol: TCP
+    port: 9091
+    targetPort: 9091
+  selector:
+    {{- include "anarchy.operatorComponentLabels" . | nindent 4 }}
+{{- end }}

--- a/helm/templates/service-monitor.yaml
+++ b/helm/templates/service-monitor.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "anarchy.selectorLabels" . | nindent 6 }}
+      {{- include "anarchy.operatorComponentLabels" . | nindent 6 }}
   namespaceSelector:
     matchNames:
     - {{ .Values.namespace.name }}

--- a/helm/templates/service-monitor.yaml
+++ b/helm/templates/service-monitor.yaml
@@ -1,0 +1,27 @@
+{{- if (and .Values.deploy .Values.metrics.enabled) -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "anarchy.name" . }}-metrics
+  namespace: {{ .Values.namespace.name }}
+  labels:
+    {{- include "anarchy.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "anarchy.selectorLabels" . | nindent 6 }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Values.namespace.name }}
+  endpoints:
+  - port: metrics
+    interval: "30s"
+    path: /metrics
+    basicAuth:
+      username:
+        name: {{ include "anarchy.name" . }}-metrics-credentials
+        key: metrics_username
+      password:
+        name: {{ include "anarchy.name" . }}-metrics-credentials
+        key: metrics_password
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,6 +53,7 @@ service:
   type: ClusterIP
   port:
     api: 5000
+    metrics: 9091
 
 ingress:
   enabled: false
@@ -73,6 +74,10 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+metrics:
+  enabled: true
+  username: metrics
 
 runners:
   default:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -53,7 +53,6 @@ service:
   type: ClusterIP
   port:
     api: 5000
-    metrics: 9091
 
 ingress:
   enabled: false

--- a/operator/anarchy.py
+++ b/operator/anarchy.py
@@ -1,13 +1,16 @@
 import json
-import kopf
-import kubernetes_asyncio
-import logging
 import os
 
-class Anarchy():
+import kubernetes_asyncio
+from metrics import TimerDecoratorMeta
+
+
+class Anarchy(metaclass=TimerDecoratorMeta):
     action_check_interval = int(os.environ.get('ACTION_CHECK_INTERVAL', 3))
     cleanup_interval = int(os.environ.get('CLEANUP_INTERVAL', 60))
     domain = os.environ.get('ANARCHY_DOMAIN', 'anarchy.gpte.redhat.com')
+    metrics_enabled = os.environ.get('METRICS_ENABLED', 'true').lower() == 'true'
+    metrics_port = int(os.environ.get('METRICS_PORT', 9091))
     run_check_interval = int(os.environ.get('RUN_CHECK_INTERVAL', 3))
     running_all_in_one = 'true' == os.environ.get('ANARCHY_RUNNING_ALL_IN_ONE', '')
     version = os.environ.get('ANARCHY_VERSION', 'v1')

--- a/operator/anarchygovernor.py
+++ b/operator/anarchygovernor.py
@@ -1,12 +1,13 @@
-import kopf
 import logging
-import pytimeparse
-
 from datetime import timedelta
 
+import kopf
+import pytimeparse
 from anarchy import Anarchy
+from metrics import TimerDecoratorMeta
 
-class AnarchyGovernor:
+
+class AnarchyGovernor(metaclass=TimerDecoratorMeta):
     cache = {}
     kind = 'AnarchyGovernor'
     plural = 'anarchygovernors'

--- a/operator/anarchykopfobject.py
+++ b/operator/anarchykopfobject.py
@@ -1,9 +1,10 @@
 import kopf
 import kubernetes_asyncio
-
 from anarchy import Anarchy
+from metrics import TimerDecoratorMeta
 
-class AnarchyKopfObject:
+
+class AnarchyKopfObject(metaclass=TimerDecoratorMeta):
     @classmethod
     def from_definition(cls, definition):
         metadata = definition['metadata']

--- a/operator/metrics/__init__.py
+++ b/operator/metrics/__init__.py
@@ -1,0 +1,11 @@
+from .app_metrics import AppMetrics
+from .metrics_service import MetricsService
+from .timer_decorator import TimerDecoratorMeta, async_timer, sync_timer
+
+__all__ = [
+    "AppMetrics",
+    "MetricsService",
+    "TimerDecoratorMeta",
+    "async_timer",
+    "sync_timer",
+]

--- a/operator/metrics/app_metrics.py
+++ b/operator/metrics/app_metrics.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from aioprometheus import REGISTRY, Histogram
+
+
+class AppMetrics:
+    registry = REGISTRY
+
+    process_time = Histogram(
+        "anarchy_process_time_seconds",
+        "Execution time of processes in the app",
+        {
+            "method": "The method name",
+            "status": "The status of the request",
+            "app": "The application name",
+            "cluster_domain": "The cluster name",
+        },
+        registry=registry,
+    )

--- a/operator/metrics/metrics_service.py
+++ b/operator/metrics/metrics_service.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import logging
+
+from aioprometheus.service import Service
+
+from .app_metrics import AppMetrics
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsService:
+    service = Service(registry=AppMetrics.registry)
+
+    @classmethod
+    async def start(cls, addr="0.0.0.0", port=9091) -> None:
+        logging.getLogger("aiohttp").setLevel(logging.ERROR)
+        await cls.service.start(addr=addr, port=port, metrics_url="/metrics")
+        logger.info(f"Serving metrics on: {cls.service.metrics_url}")
+
+    @classmethod
+    async def stop(cls) -> None:
+        logger.info("Stopping metrics service")
+        await cls.service.stop()

--- a/operator/metrics/timer_decorator.py
+++ b/operator/metrics/timer_decorator.py
@@ -1,0 +1,76 @@
+import inspect
+import os
+import time
+from functools import wraps
+
+from .app_metrics import AppMetrics
+
+cluster_domain = os.environ.get('CLUSTER_DOMAIN')
+
+def async_timer(app: str):
+    def decorator(func):
+        @wraps(func)
+        async def wrapper(*args, **kwargs):
+            start_time = time.time()
+            status = 'success'
+            try:
+                result = await func(*args, **kwargs)
+                status = 'success'
+            except Exception as e:
+                status = 'error'
+                raise e
+            finally:
+                duration = time.time() - start_time
+                labels = {
+                    'method': func.__name__,
+                    'status': status,
+                    'app': app,
+                    'cluster_domain': cluster_domain,
+                }
+                AppMetrics.process_time.observe(labels, duration)
+            return result
+        return wrapper
+    return decorator
+
+
+def sync_timer(app: str):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            start_time = time.time()
+            try:
+                result = func(*args, **kwargs)
+                status = 'success'
+            except Exception as e:
+                status = 'error'
+                raise e
+            finally:
+                duration = time.time() - start_time
+                labels = {
+                    'method': func.__name__,
+                    'status': status,
+                    'app': app,
+                    'cluster_domain': cluster_domain,
+                }
+                AppMetrics.process_time.observe(labels, duration)
+            return result
+        return wrapper
+    return decorator
+
+
+class TimerDecoratorMeta(type):
+    def __new__(cls, name, bases, dct):
+        for attr_name, attr_value in dct.items():
+            if isinstance(attr_value, classmethod):
+                original_method = attr_value.__func__
+                if inspect.iscoroutinefunction(original_method):
+                    decorated_method = async_timer(name)(original_method)
+                else:
+                    decorated_method = sync_timer(name)(original_method)
+                dct[attr_name] = classmethod(decorated_method)
+            elif callable(attr_value) and not attr_name.startswith("__"):
+                if inspect.iscoroutinefunction(attr_value):
+                    dct[attr_name] = async_timer(name)(attr_value)
+                else:
+                    dct[attr_name] = sync_timer(name)(attr_value)
+        return super().__new__(cls, name, bases, dct)

--- a/operator/operator.py
+++ b/operator/operator.py
@@ -1,23 +1,28 @@
 #!/usr/bin/env python
 
 import asyncio
-import kopf
-import kubernetes_asyncio
 import logging
 
+import kopf
+import kubernetes_asyncio
 from anarchy import Anarchy
-from anarchygovernor import AnarchyGovernor
-from anarchysubject import AnarchySubject
 from anarchyaction import AnarchyAction
+from anarchygovernor import AnarchyGovernor
 from anarchyrun import AnarchyRun
 from anarchyrunner import AnarchyRunner
+from anarchysubject import AnarchySubject
 from configure_kopf_logging import configure_kopf_logging
 from infinite_relative_backoff import InfiniteRelativeBackoff
+from metrics import MetricsService
+
 
 @kopf.on.startup()
 async def on_startup(settings: kopf.OperatorSettings, logger, **_):
     await Anarchy.on_startup()
     await AnarchyGovernor.preload()
+
+    if Anarchy.metrics_enabled:
+        await MetricsService.start(port=Anarchy.metrics_port)
 
     # Never give up from network errors
     settings.networking.error_backoffs = InfiniteRelativeBackoff()
@@ -42,6 +47,7 @@ async def on_startup(settings: kopf.OperatorSettings, logger, **_):
 @kopf.on.cleanup()
 async def on_cleanup(**_):
     await Anarchy.on_cleanup()
+    await MetricsService.stop()
 
 @kopf.on.event(Anarchy.domain, Anarchy.version, 'anarchygovernors')
 async def governor_event(event, logger, **_):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 aiofiles==25.1.0
+aioprometheus[aiohttp]==23.12.0
 ansible==12.1.0
 ansible-core==2.19.3
 ansible-runner==2.4.2

--- a/test/unittest-operator-metrics.py
+++ b/test/unittest-operator-metrics.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python
+
+import asyncio
+import sys
+import unittest
+
+sys.path.append('../operator')
+
+from metrics import (
+    AppMetrics,
+    MetricsService,
+    TimerDecoratorMeta,
+    async_timer,
+    sync_timer,
+)
+
+
+class TestAppMetrics(unittest.TestCase):
+    def test_histogram_registered(self):
+        self.assertEqual(AppMetrics.process_time.name, "anarchy_process_time_seconds")
+
+    def test_histogram_in_registry(self):
+        collectors = {c.name for c in AppMetrics.registry.get_all()}
+        self.assertIn("anarchy_process_time_seconds", collectors)
+
+
+class TestSyncTimer(unittest.TestCase):
+    def test_success(self):
+        @sync_timer(app="TestSync")
+        def add(a, b):
+            return a + b
+
+        result = add(2, 3)
+        self.assertEqual(result, 5)
+
+    def test_error(self):
+        @sync_timer(app="TestSync")
+        def fail():
+            raise ValueError("boom")
+
+        with self.assertRaises(ValueError):
+            fail()
+
+    def test_preserves_function_name(self):
+        @sync_timer(app="TestSync")
+        def my_original_name():
+            pass
+
+        self.assertEqual(my_original_name.__name__, "my_original_name")
+
+
+class TestAsyncTimer(unittest.TestCase):
+    def test_success(self):
+        @async_timer(app="TestAsync")
+        async def async_add(a, b):
+            return a + b
+
+        result = asyncio.run(async_add(10, 20))
+        self.assertEqual(result, 30)
+
+    def test_error(self):
+        @async_timer(app="TestAsync")
+        async def async_fail():
+            raise RuntimeError("async boom")
+
+        with self.assertRaises(RuntimeError):
+            asyncio.run(async_fail())
+
+    def test_preserves_function_name(self):
+        @async_timer(app="TestAsync")
+        async def my_async_func():
+            pass
+
+        self.assertEqual(my_async_func.__name__, "my_async_func")
+
+
+class TestTimerDecoratorMeta(unittest.TestCase):
+    def setUp(self):
+        class SampleClass(metaclass=TimerDecoratorMeta):
+            def instance_method(self):
+                return "instance"
+
+            @classmethod
+            def class_method(cls):
+                return "classmethod"
+
+            def __str__(self):
+                return "SampleClass"
+
+            def __repr__(self):
+                return "<SampleClass>"
+
+        self.cls = SampleClass
+        self.obj = SampleClass()
+
+    def test_instance_method_works(self):
+        self.assertEqual(self.obj.instance_method(), "instance")
+
+    def test_classmethod_works(self):
+        self.assertEqual(self.cls.class_method(), "classmethod")
+
+    def test_dunder_not_wrapped(self):
+        self.assertEqual(str(self.obj), "SampleClass")
+        self.assertEqual(repr(self.obj), "<SampleClass>")
+
+    def test_metaclass_inherited(self):
+        class Parent(metaclass=TimerDecoratorMeta):
+            def parent_method(self):
+                return "parent"
+
+        class Child(Parent):
+            def child_method(self):
+                return "child"
+
+        child = Child()
+        self.assertEqual(child.parent_method(), "parent")
+        self.assertEqual(child.child_method(), "child")
+
+
+class TestMetricsService(unittest.TestCase):
+    def test_service_has_registry(self):
+        self.assertIs(MetricsService.service.registry, AppMetrics.registry)
+
+    def test_start_is_coroutine(self):
+        self.assertTrue(asyncio.iscoroutinefunction(MetricsService.start))
+
+    def test_stop_is_coroutine(self):
+        self.assertTrue(asyncio.iscoroutinefunction(MetricsService.stop))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Methods across operator classes are automatically instrumented via a TimerDecoratorMeta metaclass that records
execution time as histograms, exposed on a /metrics HTTP endpoint for Prometheus scraping.

## Changes

- New `operator/metrics/` package with histogram definition, async  metrics service, and timer decorators (sync, async, metaclass)
- Integrate MetricsService start/stop into Kopf lifecycle hooks with  configurable toggle via METRICS_ENABLED environment variable
- Apply TimerDecoratorMeta to Anarchy, AnarchyGovernor, and  AnarchyKopfObject to instrument all public methods
- Helm chart updates: metrics port, ServiceMonitor, credentials secret,  and `metrics.enabled` toggle in values.yaml
- Grafana dashboard JSON ready for import with anarchy-specific queries
- Unit tests covering decorators, metaclass, and service configuration
