### PR TITLE
Fix delete handler labels on callbacks

### DIFF
--- a/api/anarchyaction.py
+++ b/api/anarchyaction.py
@@ -126,6 +126,10 @@ class AnarchyAction(VarSecretMixin, AnarchyObject):
             return f"{self.callback_base_url}/action/{self.name}"
 
     @property
+    def is_delete_handler(self):
+        return Anarchy.delete_handler_label in self.labels
+
+    @property
     def is_finished(self):
         return Anarchy.finished_label in self.labels
 

--- a/api/anarchyrun.py
+++ b/api/anarchyrun.py
@@ -40,37 +40,42 @@ class AnarchyRun(AnarchyWatchObject):
         anarchy_subject = await anarchy_action.get_subject()
         anarchy_governor = await anarchy_subject.get_governor()
 
+        definition = {
+            "apiVersion": Anarchy.api_version,
+            "kind": "AnarchyRun",
+            "metadata": {
+                "generateName": f"{anarchy_action.name}-{handler['name']}-",
+                "labels": {
+                    Anarchy.event_label: handler['name'],
+                    Anarchy.action_label: anarchy_action.name,
+                    Anarchy.governor_label: anarchy_governor.name,
+                    Anarchy.runner_label: 'queued',
+                    Anarchy.subject_label: anarchy_subject.name,
+                },
+                "namespace": Anarchy.namespace,
+                "ownerReferences": [anarchy_action.as_owner_ref()],
+            },
+            "spec": {
+                "action": anarchy_action.as_reference(),
+                "governor": anarchy_governor.as_reference(),
+                "handler": handler,
+                "subject": {
+                    "vars": anarchy_subject.vars,
+                    **anarchy_subject.as_reference(),
+                }
+            }
+        }
+        if anarchy_action.is_delete_handler:
+            definition['metadata']['labels'][Anarchy.delete_handler_label] = ""
+
         definition = await Anarchy.custom_objects_api.create_namespaced_custom_object(
             group = Anarchy.domain,
             namespace = Anarchy.namespace,
             plural = 'anarchyruns',
             version = Anarchy.version,
-            body = {
-                "apiVersion": Anarchy.api_version,
-                "kind": "AnarchyRun",
-                "metadata": {
-                    "generateName": f"{anarchy_action.name}-{handler['name']}-",
-                    "labels": {
-                        Anarchy.event_label: handler['name'],
-                        Anarchy.action_label: anarchy_action.name,
-                        Anarchy.governor_label: anarchy_governor.name,
-                        Anarchy.runner_label: 'queued',
-                        Anarchy.subject_label: anarchy_subject.name,
-                    },
-                    "namespace": Anarchy.namespace,
-                    "ownerReferences": [anarchy_action.as_owner_ref()],
-                },
-                "spec": {
-                    "action": anarchy_action.as_reference(),
-                    "governor": anarchy_governor.as_reference(),
-                    "handler": handler,
-                    "subject": {
-                        "vars": anarchy_subject.vars,
-                        **anarchy_subject.as_reference(),
-                    }
-                }
-            }
+            body = definition,
         )
+
         anarchy_run = cls(definition)
         await anarchy_run.cache_put()
         return anarchy_run

--- a/operator/anarchyrun.py
+++ b/operator/anarchyrun.py
@@ -253,7 +253,7 @@ class AnarchyRun(AnarchyCachedKopfObject):
         await anarchy_subject.set_run_status(self.result_status, self.result_status_message)
         if anarchy_action:
             if anarchy_action.is_labeled_for_cancelation:
-                logging.info(f"Canceling {self} after failed run for canceled {anarchy_action}")
+                logging.info("Canceling %s after failed run for canceled %s", self, anarchy_action)
                 await self.finish('canceled')
                 await anarchy_action.finish('canceled')
             else:
@@ -263,7 +263,7 @@ class AnarchyRun(AnarchyCachedKopfObject):
         await anarchy_subject.set_run_status('lost')
         if anarchy_action:
             if anarchy_action.is_labeled_for_cancelation:
-                logging.info(f"Canceling {self} after lost run for canceled {anarchy_action}")
+                logging.info("Canceling %s after lost run for canceled %s", self, anarchy_action)
                 await self.finish('canceled')
                 await anarchy_action.finish('canceled')
             else:
@@ -353,11 +353,11 @@ class AnarchyRun(AnarchyCachedKopfObject):
             # Anything pending or running is managed by the API component
             pass
         elif anarchy_action and anarchy_action.is_labeled_for_cancelation:
-            logging.info("Canceling {self} for canceled {anarchy_action}")
+            logging.info("Canceling %s for canceled %s", self, anarchy_action)
             await self.finish('canceled')
             await anarchy_action.finish('canceled')
         elif anarchy_action and anarchy_action.is_finished:
-            logging.info("Canceling {self} for finished {anarchy_action}")
+            logging.info("Canceling %s for canceled %s", self, anarchy_action)
             await self.finish('canceled')
         elif self.is_labeled_for_cancelation:
             await self.finish('canceled')

--- a/operator/anarchysubject.py
+++ b/operator/anarchysubject.py
@@ -287,7 +287,7 @@ class AnarchySubject(AnarchyCachedKopfObject):
                 anarchy_action = await self.get_active_action()
                 if anarchy_action.creation_timestamp >= self.deletion_timestamp:
                     if not anarchy_action.is_delete_handler:
-                        logging.info(f"Applying deleting label to {anarchy_action}")
+                        logging.info("Applying deleting label to %s", anarchy_action)
                         await anarchy_action.json_patch([{
                             "op": "add",
                             "path": f"/metadata/labels/{Anarchy.delete_handler_label.replace('/', '~1')}",
@@ -731,7 +731,7 @@ class AnarchySubject(AnarchyCachedKopfObject):
                 if self.is_deleting \
                 and not anarchy_run.is_delete_handler:
                     await anarchy_run.finish('canceled')
-                    logging.info("{anarchy_run} canceled because it is not related to pending delete")
+                    logging.info("%s canceled because it is not related to pending delete", anarchy_run)
                     await self.remove_run_from_status(anarchy_run)
                 else:
                     if anarchy_run.has_action:


### PR DESCRIPTION
Callbacks on delete handler actions should create AnarchyRuns that also have a delete handler label.