### PR TITLE
Fix api and anarchy-runner issues

### DIFF
--- a/api/anarchyrun.py
+++ b/api/anarchyrun.py
@@ -244,15 +244,10 @@ class AnarchyRun(AnarchyWatchObject):
             plural = self.plural,
             version = Anarchy.version,
         )
-        await self.json_patch_status([{
-            "op": "add",
-            "path": "/status/runner",
-            "value": anarchy_runner.as_reference(),
-        }, {
-            "op": "add",
-            "path": "/status/runnerPod",
-            "value": anarchy_runner_pod.as_reference(),
-        }])
+        await self.merge_patch_status({
+            "runner": anarchy_runner.as_reference(),
+            "runnerPod": anarchy_runner_pod.as_reference(),
+        })
         logging.info(f"Assigned {self} to {anarchy_runner_pod}")
 
     async def cache_put(self):

--- a/api/app.py
+++ b/api/app.py
@@ -115,11 +115,11 @@ async def get_run(request):
 
     if anarchy_runner_pod.is_deleting:
         logging.info("Not giving AnarchyRun to %s because it is being deleted", anarchy_runner_pod)
-        return None
+        raise ResponseError.FORBIDDEN("Runner pod is deleting")
     elif anarchy_runner_pod.is_marked_for_termination:
         logging.info("Deleting %s that is marked for termination", anarchy_runner_pod)
         await anarchy_runner_pod.delete()
-        return None
+        raise ResponseError.FORBIDDEN("Runner pod marked for termination")
 
     anarchy_run = await AnarchyRun.get_run_for_runner_pod(anarchy_runner, anarchy_runner_pod, Anarchy.poll_timeout)
 


### PR DESCRIPTION
- Fix to use merge patch to update status on runner pod assignment to prevent issue when AnarchyRun does not have status set.
- Fix fast retry from terminating runner pod by returning 403 FORBIDDEN from api.