### PR TITLE
fix: correct TemporaryError args, JSON patch path typo, and 429 retries

### DIFF
--- a/api/anarchywatchobject.py
+++ b/api/anarchywatchobject.py
@@ -107,7 +107,7 @@ class AnarchyWatchObject(AnarchyObject):
                     if event_object['reason'] in ('Expired', 'Gone'):
                         raise WatchRestartError(event_object['reason'].lower())
                     else:
-                        raise WatchError(f"{event_obj['reason']} {event_obj['message']}")
+                        raise WatchError(f"{event_object['reason']} {event_object['message']}")
                 else:
                     raise WatchError(f"UKNOWN EVENT: {event}")
             elif event_type == 'DELETED':
@@ -125,6 +125,8 @@ class AnarchyWatchObject(AnarchyObject):
             except asyncio.CancelledError:
                 logging.info(f"Watch {cls.__name__} exiting")
                 return
+            except WatchRestartError:
+                logging.info(f"Watch {cls.__name__} restarting")
             except Exception as e:
                 if isinstance(e, kubernetes_asyncio.client.exceptions.ApiException) and e.status == 410:
                     logging.debug(f"Watch {cls.__name__} received 410 GONE")
@@ -134,7 +136,7 @@ class AnarchyWatchObject(AnarchyObject):
                 # If watch is repeatedly crashing then backoff retry
                 watch_duration = time.time() - watch_start_time
                 if watch_duration < 60:
-                    asyncio.sleep(60 - watch_duration)
+                    await asyncio.sleep(60 - watch_duration)
 
                 logging.info(f"Watch {cls.__name__} restarting")
 

--- a/operator/anarchysubject.py
+++ b/operator/anarchysubject.py
@@ -199,8 +199,7 @@ class AnarchySubject(AnarchyCachedKopfObject):
                     raise
         else:
             raise kopf.TemporaryError(
-                "Failed to add %s to %s status after %s retries",
-                anarchy_run, self, max_retries,
+                f"Failed to add {anarchy_run} to {self} status after {max_retries} retries",
             )
         if add_as_active:
             logging.info("Added %s as active run for %s", anarchy_run, self)
@@ -622,7 +621,7 @@ class AnarchySubject(AnarchyCachedKopfObject):
                             })
                             patch.insert(0, {
                                 "op": "test",
-                                "path": "f/status/pendingActions/{i}/name",
+                                "path": f"/status/pendingActions/{i}/name",
                                 "value": anarchy_action.name
                             })
                 if patch:
@@ -635,8 +634,7 @@ class AnarchySubject(AnarchyCachedKopfObject):
                     logging.error(f"Failed to apply {patch} to {self}")
                     raise
         raise kopf.TemporaryError(
-            "Failed to remove %s from %s status after %s retries",
-            anarchy_action, self, max_retries,
+            f"Failed to remove {anarchy_action} from {self} status after {max_retries} retries",
         )
 
     async def remove_anarchy_finalizers(self):

--- a/operator/operator.py
+++ b/operator/operator.py
@@ -421,6 +421,11 @@ async def run_daemon(stopped, **kwargs):
             except K8sApiException as err:
                 if err.status == 404:
                     return
+                if err.status == 429:
+                    retry_after = int(err.headers.get('Retry-After', 5))
+                    logging.warning("API server returned 429, retrying after %ds", retry_after)
+                    await asyncio.sleep(retry_after)
+                    continue
                 raise
             if anarchy_run.ignore or anarchy_subject.ignore:
                 return
@@ -430,6 +435,11 @@ async def run_daemon(stopped, **kwargs):
                 except K8sApiException as err:
                     if err.status == 404:
                         return
+                    if err.status == 429:
+                        retry_after = int(err.headers.get('Retry-After', 5))
+                        logging.warning("API server returned 429, retrying after %ds", retry_after)
+                        await asyncio.sleep(retry_after)
+                        continue
                 if anarchy_action.ignore:
                     raise kopf.TemporaryError(
                         f"Refusing to handle {anarchy_run} when {anarchy_action} is marked with ignore",


### PR DESCRIPTION
Fixes operator and API bugs found while investigating error spikes on the Grafana dashboard.

**Operator** (introduced in PR #167, commit 2f129ac):

- `kopf.TemporaryError` called with `%s`-style positional args instead of a formatted string, causing `TypeError`
- JSON Patch path typo (`"f/status/..."` instead of `f"/status/..."`) causing 422 failures and retry exhaustion
- K8s API 429 responses now respect `Retry-After` header instead of waiting 60s

**API** (`AnarchyWatchObject`):

- Missing `await` on `asyncio.sleep` in watch backoff, causing immediate restart loops
- `NameError` on undefined `event_obj` variable (should be `event_object`)
- `WatchRestartError` handled separately so expected watch restarts don't pollute error metrics
