### PR TITLE
Tune AnarchyRunner scaling for burst workloads

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -83,13 +83,13 @@ metrics:
 
 runners:
   default:
-    consecutiveFailureLimit: 10
+    consecutiveFailureLimit: 20
     maxReplicas: 10
     minReplicas: 1
     runLimit: 100
-    scaleUpDelay: 5m
-    scaleUpThreshold: 20
-    scalingCheckInterval: 1m
+    scaleUpDelay: 30s
+    scaleUpThreshold: 5
+    scalingCheckInterval: 15s
     resources:
       limits:
         cpu: "1"


### PR DESCRIPTION
Reduce to reach maxReplicas faster under load:
  scaleUpDelay (5m->30s)
  scaleUpThreshold (20->5)
  scalingCheckInterval (1m->15s)
Increase consecutiveFailureLimit (10→20) to reduce pod churn during mixed-failure workloads.