### PR TITLE
fix: update local state after runner assignment

### DIFF
--- a/api/anarchyrun.py
+++ b/api/anarchyrun.py
@@ -244,6 +244,12 @@ class AnarchyRun(AnarchyWatchObject):
             plural = self.plural,
             version = Anarchy.version,
         )
+        # Update local state immediately so that runner_state and
+        # runner_assignments are current before the K8s watch fires.
+        # Without this a fast runner (which processes runs in ~200ms)
+        # hits POST /run/{name} before the watch updates self.definition,
+        # causing "Runner state mismatch" 400 errors.
+        await self.update_definition(definition)
         await self.merge_patch_status({
             "runner": anarchy_runner.as_reference(),
             "runnerPod": anarchy_runner_pod.as_reference(),


### PR DESCRIPTION
assign_runner_pod uses deepcopy + replace_namespaced_custom_object to set the runner label on an AnarchyRun, but never updates self.definition with the result. This means runner_state (which reads from self.definition['metadata']['labels']) returns the stale pre-assignment value until the K8s watch fires and calls update_definition.

The Ansible runner never hit this because it processes runs in seconds, giving the watch time to catch up. The Go runner processes runs in ~200ms, consistently beating the watch. This causes two failures:

1. POST /run/{name} (postResult) fails with 400 because the API checks anarchy_run.runner_state \!= anarchy_runner_pod.name — stale label.
2. PATCH /run/subject/{name} (SubjectUpdate) fails with 400 because runner_assignments (populated by update_definition via watch) is empty — the watch hasn't fired yet.

The fix is one line: await self.update_definition(definition) after the K8s replace. This updates self.definition immediately (fixing runner_state) and calls update_runner_assignment (fixing runner_assignments). When the watch eventually fires with the same resourceVersion, handle_watch_found short-circuits (line 37).

This mirrors what AnarchyObject.replace() already does — assign_runner_pod was the only codepath that inlined the K8s replace without updating local state.