### PR TITLE
Add anarchy_runner_pending_runs Prometheus gauge

### DIFF
--- a/api/anarchyrun.py
+++ b/api/anarchyrun.py
@@ -11,6 +11,7 @@ import anarchysubject
 import kubernetes_asyncio
 from anarchy import Anarchy
 from anarchywatchobject import AnarchyWatchObject
+from metrics import AppMetrics
 
 
 class AnarchyRun(AnarchyWatchObject):
@@ -232,6 +233,10 @@ class AnarchyRun(AnarchyWatchObject):
                 self.notify_run_available()
         elif self.name in self.pending_run_names:
             self.pending_run_names.remove(self.name)
+        AppMetrics.pending_runs.set(
+            {"namespace": Anarchy.namespace},
+            len(self.pending_run_names),
+        )
 
     async def assign_runner_pod(self, anarchy_runner, anarchy_runner_pod):
         definition = deepcopy(self.definition)

--- a/api/anarchyrunner.py
+++ b/api/anarchyrunner.py
@@ -2,6 +2,7 @@ import logging
 
 from anarchy import Anarchy
 from anarchywatchobject import AnarchyWatchObject
+from metrics import AppMetrics
 
 import anarchyrun
 import anarchyrunnerpod
@@ -11,6 +12,20 @@ class AnarchyRunner(AnarchyWatchObject):
     kind = 'AnarchyRunner'
     plural = 'anarchyrunners'
     preload = True
+
+    @classmethod
+    def handle_watch_deleted(cls, event_object):
+        if isinstance(event_object, dict):
+            name = event_object['metadata']['name']
+            namespace = event_object['metadata']['namespace']
+        else:
+            name = event_object.metadata.name
+            namespace = event_object.metadata.namespace
+        AppMetrics.pending_runs.set(
+            {"runner_name": name, "namespace": namespace},
+            0,
+        )
+        super().handle_watch_deleted(event_object)
 
     @classmethod
     async def on_startup(cls):
@@ -39,6 +54,11 @@ class AnarchyRunner(AnarchyWatchObject):
         logging.info(f"Cache preloaded {default}")
 
     async def update_status(self):
+        pending_count = len(anarchyrun.AnarchyRun.pending_run_names)
+        AppMetrics.pending_runs.set(
+            {"runner_name": self.name, "namespace": self.namespace},
+            pending_count,
+        )
         if Anarchy.running_all_in_one:
             return
         pods_status = []

--- a/api/anarchyrunner.py
+++ b/api/anarchyrunner.py
@@ -14,20 +14,6 @@ class AnarchyRunner(AnarchyWatchObject):
     preload = True
 
     @classmethod
-    def handle_watch_deleted(cls, event_object):
-        if isinstance(event_object, dict):
-            name = event_object['metadata']['name']
-            namespace = event_object['metadata']['namespace']
-        else:
-            name = event_object.metadata.name
-            namespace = event_object.metadata.namespace
-        AppMetrics.pending_runs.set(
-            {"runner_name": name, "namespace": namespace},
-            0,
-        )
-        super().handle_watch_deleted(event_object)
-
-    @classmethod
     async def on_startup(cls):
         if Anarchy.running_all_in_one:
             await cls.on_startup_running_all_in_one()
@@ -56,7 +42,7 @@ class AnarchyRunner(AnarchyWatchObject):
     async def update_status(self):
         pending_count = len(anarchyrun.AnarchyRun.pending_run_names)
         AppMetrics.pending_runs.set(
-            {"runner_name": self.name, "namespace": self.namespace},
+            {"namespace": self.namespace},
             pending_count,
         )
         if Anarchy.running_all_in_one:

--- a/api/anarchyrunner.py
+++ b/api/anarchyrunner.py
@@ -2,7 +2,6 @@ import logging
 
 from anarchy import Anarchy
 from anarchywatchobject import AnarchyWatchObject
-from metrics import AppMetrics
 
 import anarchyrun
 import anarchyrunnerpod
@@ -40,11 +39,6 @@ class AnarchyRunner(AnarchyWatchObject):
         logging.info(f"Cache preloaded {default}")
 
     async def update_status(self):
-        pending_count = len(anarchyrun.AnarchyRun.pending_run_names)
-        AppMetrics.pending_runs.set(
-            {"namespace": self.namespace},
-            pending_count,
-        )
         if Anarchy.running_all_in_one:
             return
         pods_status = []

--- a/api/metrics/app_metrics.py
+++ b/api/metrics/app_metrics.py
@@ -33,9 +33,8 @@ class AppMetrics:
 
     pending_runs = Gauge(
         "anarchy_runner_pending_runs",
-        "Number of pending runs waiting for a runner pod",
+        "Total number of pending AnarchyRuns in the namespace",
         {
-            "runner_name": "The AnarchyRunner resource name",
             "namespace": "The Kubernetes namespace",
         },
         registry=registry,

--- a/api/metrics/app_metrics.py
+++ b/api/metrics/app_metrics.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from aioprometheus import REGISTRY, Histogram
+from aioprometheus import REGISTRY, Gauge, Histogram
 
 
 class AppMetrics:
@@ -27,6 +27,16 @@ class AppMetrics:
             "route": "The handler function name (e.g. get_run, post_action)",
             "status": "The HTTP status code",
             "cluster_domain": "The cluster name",
+        },
+        registry=registry,
+    )
+
+    pending_runs = Gauge(
+        "anarchy_runner_pending_runs",
+        "Number of pending runs waiting for a runner pod",
+        {
+            "runner_name": "The AnarchyRunner resource name",
+            "namespace": "The Kubernetes namespace",
         },
         registry=registry,
     )

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -4186,7 +4186,6 @@
                 "indexByName": {},
                 "renameByName": {
                   "namespace": "Namespace",
-                  "runner_name": "Runner",
                   "Value": "Pending Runs"
                 }
               }

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -1,53 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS",
-      "label": "Prometheus",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "12.3.0"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "stat",
-      "name": "Stat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -92,12 +43,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 5,
   "links": [],
   "panels": [
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "000000025"
       },
       "description": "Current API HTTP requests per second.",
       "fieldConfig": {
@@ -111,7 +63,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               }
             ]
           },
@@ -143,14 +95,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
-      "type": "stat",
-      "title": "API Request Rate",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "editorMode": "code",
           "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count[5m]))",
@@ -159,12 +109,14 @@
           "range": false,
           "refId": "A"
         }
-      ]
+      ],
+      "title": "API Request Rate",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "000000025"
       },
       "description": "Average HTTP response time across all API endpoints.",
       "fieldConfig": {
@@ -178,7 +130,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -218,14 +170,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
-      "type": "stat",
-      "title": "API Avg Latency",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "editorMode": "code",
           "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum[5m])) / sum(rate(anarchy_api_http_request_duration_seconds_count[5m]))",
@@ -234,12 +184,14 @@
           "range": false,
           "refId": "A"
         }
-      ]
+      ],
+      "title": "API Avg Latency",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "000000025"
       },
       "description": "Percentage of API requests returning 4xx/5xx status codes.",
       "fieldConfig": {
@@ -253,7 +205,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -293,14 +245,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
-      "type": "stat",
-      "title": "API HTTP Error Rate",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "editorMode": "code",
           "expr": "100 * sum(rate(anarchy_api_http_request_duration_seconds_count{status=~\"4..|5..\"}[5m])) / clamp_min(sum(rate(anarchy_api_http_request_duration_seconds_count[5m])), 1e-10)",
@@ -309,12 +259,14 @@
           "range": false,
           "refId": "A"
         }
-      ]
+      ],
+      "title": "API HTTP Error Rate",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "000000025"
       },
       "description": "Percentage of class method executions ending in error (operator + API).",
       "fieldConfig": {
@@ -328,7 +280,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "yellow",
@@ -368,14 +320,12 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.3.0",
-      "type": "stat",
-      "title": "Process Error Rate",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "editorMode": "code",
           "expr": "100 * sum(rate(anarchy_process_time_seconds_count{status=\"error\"}[5m])) / clamp_min(sum(rate(anarchy_process_time_seconds_count[5m])), 1e-10)",
@@ -384,12 +334,14 @@
           "range": false,
           "refId": "A"
         }
-      ]
+      ],
+      "title": "Process Error Rate",
+      "type": "stat"
     },
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "000000025"
       },
       "description": "Shows the percentage of errors per application  and method over the last 24 hours. Calculated as 100 * increase(error) / increase(error + success) from the reporting_process_time_seconds_count counter. Uses an instant query; each gauge represents one app. Sorted descending. Suggested thresholds: 1% (warn), 5% (critical).",
       "fieldConfig": {
@@ -449,7 +401,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -467,7 +419,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "${DS_PROMETHEUS}"
+        "uid": "000000025"
       },
       "description": "Shows the percentage of errors per application over the last 24 hours. Calculated as 100 * increase(error) / increase(error + success) from the reporting_process_time_seconds_count counter. Uses an instant query; each gauge represents one app. Sorted descending. Suggested thresholds: 1% (warn), 5% (critical).",
       "fieldConfig": {
@@ -527,7 +479,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -555,7 +507,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -646,7 +598,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route, method)",
@@ -662,7 +614,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -753,7 +705,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum{route=~\"$route\"}[5m])) by (route) / sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route)",
@@ -769,7 +721,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -860,7 +812,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route))",
@@ -876,7 +828,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -967,7 +919,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{status=~\"4..|5..\", route=~\"$route\"}[5m])) by (route, status)",
@@ -983,7 +935,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -1042,7 +994,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1060,7 +1012,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -1151,7 +1103,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route))",
@@ -1167,7 +1119,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -1258,7 +1210,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (status)",
@@ -1274,7 +1226,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -1324,7 +1276,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_api_http_request_duration_seconds_count[1h])) by (method)",
@@ -1341,7 +1293,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -1391,7 +1343,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sort_desc(sum(increase(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[1h])) by (route))",
@@ -1408,7 +1360,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -1499,7 +1451,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum{route=~\"$route\"}[5m])) / sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m]))",
@@ -1511,7 +1463,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le))",
@@ -1523,7 +1475,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le))",
@@ -1539,7 +1491,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -1693,7 +1645,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum{route=~\"$route\"}[5m])) by (route, method) / sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route, method)",
@@ -1705,7 +1657,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route, method))",
@@ -1717,7 +1669,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route, method))",
@@ -1729,7 +1681,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route, method)",
@@ -1783,7 +1735,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the average duration of process executions for each method, grouped by method and app over time.",
           "fieldConfig": {
@@ -1875,7 +1827,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)\n/\nsum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -1891,7 +1843,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the 95th percentile of execution times, providing insights into the longest durations affecting most requests.",
           "fieldConfig": {
@@ -1983,7 +1935,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app))",
@@ -1999,7 +1951,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the total time spent on process executions for each method, aggregated over time.",
           "fieldConfig": {
@@ -2091,7 +2043,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2107,7 +2059,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -2200,7 +2152,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2216,7 +2168,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -2309,7 +2261,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2325,7 +2277,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "99th percentile execution time per class. Captures extreme outliers that P95 might miss.",
           "fieldConfig": {
@@ -2417,7 +2369,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app))",
@@ -2433,7 +2385,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "Instantaneous execution rate per class, showing how many method calls per second each class handles.",
           "fieldConfig": {
@@ -2525,7 +2477,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2541,7 +2493,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "Combined view of average, P95, and P99 latency for the selected class(es).",
           "fieldConfig": {
@@ -2633,7 +2585,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) / sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m]))",
@@ -2645,7 +2597,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le))",
@@ -2657,7 +2609,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le))",
@@ -2673,7 +2625,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "Classes with the highest execution volume in the last hour.",
           "fieldConfig": {
@@ -2724,7 +2676,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sort_desc(sum(increase(anarchy_process_time_seconds_count{status=\"success\", component=~\"$component\"}[1h])) by (app))",
@@ -2741,7 +2693,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "Stacked view of success and error executions per class, showing the proportion of failures.",
           "fieldConfig": {
@@ -2833,7 +2785,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2845,7 +2797,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2875,7 +2827,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the average duration of process executions for each method, grouped by method and app over time.",
           "fieldConfig": {
@@ -2970,7 +2922,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)\n/\nsum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -2986,7 +2938,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the 95th percentile of execution times, providing insights into the longest durations affecting most requests.",
           "fieldConfig": {
@@ -3079,7 +3031,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3095,7 +3047,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the total time spent on process executions for each method, aggregated over time.",
           "fieldConfig": {
@@ -3186,7 +3138,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3202,7 +3154,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -3295,7 +3247,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3311,7 +3263,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -3402,7 +3354,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[$interval])) by (app, method)",
@@ -3418,7 +3370,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "99th percentile execution time per method within each class.",
           "fieldConfig": {
@@ -3510,7 +3462,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3526,7 +3478,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "description": "Table ranking methods by latency with average, P95, P99, and execution rate.",
           "fieldConfig": {
@@ -3701,7 +3653,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method) / sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3713,7 +3665,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3725,7 +3677,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3737,7 +3689,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3749,7 +3701,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[1h])) by (app, method)",
@@ -3790,7 +3742,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "${DS_PROMETHEUS}"
+            "uid": "000000025"
           },
           "fieldConfig": {
             "defaults": {
@@ -3873,7 +3825,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "${DS_PROMETHEUS}"
+                "uid": "000000025"
               },
               "editorMode": "code",
               "expr": "sum by (app, method, status) ( increase(anarchy_process_time_seconds_count{status=\"error\", component=~\"$component\"}[1h]) )",
@@ -3889,6 +3841,360 @@
       ],
       "title": "Process Detail",
       "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 300,
+      "title": "Runner Pending Runs",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000025"
+          },
+          "description": "Total number of pending runs across all runners and namespaces.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 0,
+            "y": 16
+          },
+          "id": 301,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000025"
+              },
+              "expr": "sum(anarchy_runner_pending_runs > 0)",
+              "legendFormat": "Total",
+              "refId": "A"
+            }
+          ],
+          "title": "Total Pending Runs",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000025"
+          },
+          "description": "Top 10 namespaces with the most pending runs.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-blues"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 18,
+            "x": 6,
+            "y": 16
+          },
+          "id": 302,
+          "options": {
+            "displayMode": "gradient",
+            "minVizHeight": 10,
+            "minVizWidth": 0,
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showUnfilled": true
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000025"
+              },
+              "expr": "topk(10, sum(anarchy_runner_pending_runs > 0) by (namespace))",
+              "legendFormat": "{{namespace}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Top 10 Namespaces by Pending Runs",
+          "type": "bargauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000025"
+          },
+          "description": "Aggregated pending runs over time across all runners.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "Pending Runs",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 20,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 20
+          },
+          "id": 303,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom"
+            },
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000025"
+              },
+              "expr": "sum(anarchy_runner_pending_runs)",
+              "legendFormat": "Total Pending",
+              "refId": "A"
+            }
+          ],
+          "title": "Pending Runs Over Time (Total)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "000000025"
+          },
+          "description": "Current pending runs per runner, showing only runners with pending runs > 0.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "displayMode": "auto",
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 50
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Value"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Pending Runs"
+                  },
+                  {
+                    "id": "custom.displayMode",
+                    "value": "color-background-solid"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 20
+          },
+          "id": 304,
+          "options": {
+            "footer": {
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": true
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Pending Runs"
+              }
+            ]
+          },
+          "pluginVersion": "9.5.2",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "000000025"
+              },
+              "expr": "anarchy_runner_pending_runs > 0",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Pending Runs per Namespace",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true,
+                  "__name__": true,
+                  "job": true,
+                  "instance": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "namespace": "Namespace",
+                  "runner_name": "Runner",
+                  "Value": "Pending Runs"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ]
     }
   ],
   "preload": false,
@@ -3898,7 +4204,10 @@
   "templating": {
     "list": [
       {
-        "current": {},
+        "current": {
+          "text": "BABYLON_DEV",
+          "value": "babylon-dev"
+        },
         "includeAll": false,
         "label": "Datasource",
         "name": "datasource",
@@ -3909,10 +4218,17 @@
         "type": "datasource"
       },
       {
-        "current": {},
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "000000025"
         },
         "definition": "label_values(anarchy_process_time_seconds_bucket, component)",
         "includeAll": true,
@@ -3931,10 +4247,17 @@
         "type": "query"
       },
       {
-        "current": {},
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "000000025"
         },
         "definition": "label_values(anarchy_process_time_seconds_bucket{component=~\"$component\"}, app)",
         "includeAll": true,
@@ -3953,10 +4276,17 @@
         "type": "query"
       },
       {
-        "current": {},
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "datasource": {
           "type": "prometheus",
-          "uid": "${DS_PROMETHEUS}"
+          "uid": "000000025"
         },
         "definition": "label_values(anarchy_api_http_request_duration_seconds_bucket, route)",
         "includeAll": true,
@@ -4055,7 +4385,5 @@
   "timezone": "browser",
   "title": "Anarchy Observability",
   "uid": "anarchy-observability",
-  "version": 7,
-  "weekStart": "",
-  "id": null
+  "version": 8
 }

--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -49,7 +49,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "000000025"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Current API HTTP requests per second.",
       "fieldConfig": {
@@ -100,7 +100,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count[5m]))",
@@ -116,7 +116,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "000000025"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Average HTTP response time across all API endpoints.",
       "fieldConfig": {
@@ -175,7 +175,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum[5m])) / sum(rate(anarchy_api_http_request_duration_seconds_count[5m]))",
@@ -191,7 +191,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "000000025"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Percentage of API requests returning 4xx/5xx status codes.",
       "fieldConfig": {
@@ -250,7 +250,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "100 * sum(rate(anarchy_api_http_request_duration_seconds_count{status=~\"4..|5..\"}[5m])) / clamp_min(sum(rate(anarchy_api_http_request_duration_seconds_count[5m])), 1e-10)",
@@ -266,7 +266,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "000000025"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Percentage of class method executions ending in error (operator + API).",
       "fieldConfig": {
@@ -325,7 +325,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "expr": "100 * sum(rate(anarchy_process_time_seconds_count{status=\"error\"}[5m])) / clamp_min(sum(rate(anarchy_process_time_seconds_count[5m])), 1e-10)",
@@ -341,7 +341,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "000000025"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Shows the percentage of errors per application  and method over the last 24 hours. Calculated as 100 * increase(error) / increase(error + success) from the reporting_process_time_seconds_count counter. Uses an instant query; each gauge represents one app. Sorted descending. Suggested thresholds: 1% (warn), 5% (critical).",
       "fieldConfig": {
@@ -401,7 +401,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -419,7 +419,7 @@
     {
       "datasource": {
         "type": "prometheus",
-        "uid": "000000025"
+        "uid": "${DS_PROMETHEUS}"
       },
       "description": "Shows the percentage of errors per application over the last 24 hours. Calculated as 100 * increase(error) / increase(error + success) from the reporting_process_time_seconds_count counter. Uses an instant query; each gauge represents one app. Sorted descending. Suggested thresholds: 1% (warn), 5% (critical).",
       "fieldConfig": {
@@ -479,7 +479,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
           "exemplar": false,
@@ -507,7 +507,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -598,7 +598,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route, method)",
@@ -614,7 +614,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -705,7 +705,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum{route=~\"$route\"}[5m])) by (route) / sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route)",
@@ -721,7 +721,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -812,7 +812,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route))",
@@ -828,7 +828,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -919,7 +919,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{status=~\"4..|5..\", route=~\"$route\"}[5m])) by (route, status)",
@@ -935,7 +935,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -994,7 +994,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "exemplar": false,
@@ -1012,7 +1012,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1103,7 +1103,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route))",
@@ -1119,7 +1119,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1210,7 +1210,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (status)",
@@ -1226,7 +1226,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1276,7 +1276,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_api_http_request_duration_seconds_count[1h])) by (method)",
@@ -1293,7 +1293,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1343,7 +1343,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sort_desc(sum(increase(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[1h])) by (route))",
@@ -1360,7 +1360,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1451,7 +1451,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum{route=~\"$route\"}[5m])) / sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m]))",
@@ -1463,7 +1463,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le))",
@@ -1475,7 +1475,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le))",
@@ -1491,7 +1491,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -1645,7 +1645,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_sum{route=~\"$route\"}[5m])) by (route, method) / sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route, method)",
@@ -1657,7 +1657,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route, method))",
@@ -1669,7 +1669,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_api_http_request_duration_seconds_bucket{route=~\"$route\"}[5m])) by (le, route, method))",
@@ -1681,7 +1681,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_api_http_request_duration_seconds_count{route=~\"$route\"}[5m])) by (route, method)",
@@ -1735,7 +1735,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the average duration of process executions for each method, grouped by method and app over time.",
           "fieldConfig": {
@@ -1827,7 +1827,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)\n/\nsum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -1843,7 +1843,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the 95th percentile of execution times, providing insights into the longest durations affecting most requests.",
           "fieldConfig": {
@@ -1935,7 +1935,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app))",
@@ -1951,7 +1951,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the total time spent on process executions for each method, aggregated over time.",
           "fieldConfig": {
@@ -2043,7 +2043,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2059,7 +2059,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -2152,7 +2152,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2168,7 +2168,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -2261,7 +2261,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2277,7 +2277,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile execution time per class. Captures extreme outliers that P95 might miss.",
           "fieldConfig": {
@@ -2369,7 +2369,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app))",
@@ -2385,7 +2385,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Instantaneous execution rate per class, showing how many method calls per second each class handles.",
           "fieldConfig": {
@@ -2477,7 +2477,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2493,7 +2493,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Combined view of average, P95, and P99 latency for the selected class(es).",
           "fieldConfig": {
@@ -2585,7 +2585,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) / sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m]))",
@@ -2597,7 +2597,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le))",
@@ -2609,7 +2609,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le))",
@@ -2625,7 +2625,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Classes with the highest execution volume in the last hour.",
           "fieldConfig": {
@@ -2676,7 +2676,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sort_desc(sum(increase(anarchy_process_time_seconds_count{status=\"success\", component=~\"$component\"}[1h])) by (app))",
@@ -2693,7 +2693,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Stacked view of success and error executions per class, showing the proportion of failures.",
           "fieldConfig": {
@@ -2785,7 +2785,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2797,7 +2797,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[5m])) by (app)",
@@ -2827,7 +2827,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the average duration of process executions for each method, grouped by method and app over time.",
           "fieldConfig": {
@@ -2922,7 +2922,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)\n/\nsum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -2938,7 +2938,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the 95th percentile of execution times, providing insights into the longest durations affecting most requests.",
           "fieldConfig": {
@@ -3031,7 +3031,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3047,7 +3047,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the total time spent on process executions for each method, aggregated over time.",
           "fieldConfig": {
@@ -3138,7 +3138,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3154,7 +3154,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -3247,7 +3247,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3263,7 +3263,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "This chart shows the total number of successful executions per method, updated every 5 minutes.",
           "fieldConfig": {
@@ -3354,7 +3354,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[$interval])) by (app, method)",
@@ -3370,7 +3370,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "99th percentile execution time per method within each class.",
           "fieldConfig": {
@@ -3462,7 +3462,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3478,7 +3478,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Table ranking methods by latency with average, P95, P99, and execution rate.",
           "fieldConfig": {
@@ -3653,7 +3653,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_sum{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method) / sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3665,7 +3665,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.95, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3677,7 +3677,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "histogram_quantile(0.99, sum(rate(anarchy_process_time_seconds_bucket{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (le, app, method))",
@@ -3689,7 +3689,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(rate(anarchy_process_time_seconds_count{status=\"success\", app=~\"$app\", component=~\"$component\"}[5m])) by (app, method)",
@@ -3701,7 +3701,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum(increase(anarchy_process_time_seconds_count{status=\"error\", app=~\"$app\", component=~\"$component\"}[1h])) by (app, method)",
@@ -3742,7 +3742,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "fieldConfig": {
             "defaults": {
@@ -3825,7 +3825,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "editorMode": "code",
               "expr": "sum by (app, method, status) ( increase(anarchy_process_time_seconds_count{status=\"error\", component=~\"$component\"}[1h]) )",
@@ -3857,7 +3857,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Total number of pending runs across all runners and namespaces.",
           "fieldConfig": {
@@ -3912,7 +3912,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum(anarchy_runner_pending_runs > 0)",
               "legendFormat": "Total",
@@ -3925,7 +3925,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Top 10 namespaces with the most pending runs.",
           "fieldConfig": {
@@ -3980,7 +3980,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "topk(10, sum(anarchy_runner_pending_runs > 0) by (namespace))",
               "legendFormat": "{{namespace}}",
@@ -3993,7 +3993,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Aggregated pending runs over time across all runners.",
           "fieldConfig": {
@@ -4071,7 +4071,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "sum(anarchy_runner_pending_runs)",
               "legendFormat": "Total Pending",
@@ -4084,7 +4084,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "000000025"
+            "uid": "${DS_PROMETHEUS}"
           },
           "description": "Current pending runs per runner, showing only runners with pending runs > 0.",
           "fieldConfig": {
@@ -4163,7 +4163,7 @@
             {
               "datasource": {
                 "type": "prometheus",
-                "uid": "000000025"
+                "uid": "${DS_PROMETHEUS}"
               },
               "expr": "anarchy_runner_pending_runs > 0",
               "format": "table",
@@ -4227,7 +4227,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "000000025"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(anarchy_process_time_seconds_bucket, component)",
         "includeAll": true,
@@ -4256,7 +4256,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "000000025"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(anarchy_process_time_seconds_bucket{component=~\"$component\"}, app)",
         "includeAll": true,
@@ -4285,7 +4285,7 @@
         },
         "datasource": {
           "type": "prometheus",
-          "uid": "000000025"
+          "uid": "${DS_PROMETHEUS}"
         },
         "definition": "label_values(anarchy_api_http_request_duration_seconds_bucket, route)",
         "includeAll": true,


### PR DESCRIPTION
## Motivation

Until now there was no visibility into the pending runs queue depth across namespaces.
This gauge provides real-time observability in Grafana and, looking ahead, can serve as
a scaling signal for HPA on the runners via prometheus-adapter — no further code changes
needed when that time comes.

## Summary

- Add `anarchy_runner_pending_runs` Gauge (aioprometheus) to the API component (port 9092),
  labeled by namespace
- Updated in `AnarchyRun.update_pending_run_names()` on every run state change via the
  watch loop — real-time accuracy, no dependency on runner HTTP interactions
- Uses the same `pending_run_names` list that already drives runner scaling decisions
- Works in all modes including `running_all_in_one` (dev/odo)
- Add collapsed "Runner Pending Runs" row to Grafana dashboard with 4 panels:
  stat (total), bar gauge (top 10 namespaces), timeseries (trend), table (drill-down)
- All panels filter `> 0` to reduce noise across 30+ namespaces
- Validated in live cluster: gauge tracked 29→0 pending runs accurately during
  a 30-deployment destroy cycle in babylon-anarchy-test