### PR TITLE
feat(operator): support externally managed runner pods

### DIFF
--- a/operator/anarchyrunner.py
+++ b/operator/anarchyrunner.py
@@ -255,6 +255,8 @@ class AnarchyRunner(AnarchyCachedKopfObject):
             await self.create_runner_pod(logger=logger)
 
     async def manage_pod(self, pod, logger):
+        if self.ignore_pod_management:
+            return
         for entry in self.status.get('pods', []):
             if entry['name'] == pod.metadata.name:
                 consecutive_failure_count = entry.get('consecutiveFailureCount', 0)
@@ -299,6 +301,8 @@ class AnarchyRunner(AnarchyCachedKopfObject):
         self.pods[pod.metadata.name] = pod
 
     async def manage_service_account(self):
+        if self.ignore_pod_management:
+            return
         try:
             await Anarchy.core_v1_api.read_namespaced_service_account(self.service_account_name, Anarchy.namespace)
             return
@@ -307,8 +311,8 @@ class AnarchyRunner(AnarchyCachedKopfObject):
                 raise
         service_account = await Anarchy.core_v1_api.create_namespaced_service_account(
             Anarchy.namespace,
-            kubernetes.client.V1ServiceAccount(
-                metadata = kubernetes.client.V1ObjectMeta(
+            kubernetes_asyncio.client.V1ServiceAccount(
+                metadata = kubernetes_asyncio.client.V1ObjectMeta(
                     name = self.service_account_name,
                     owner_references = [self.as_owner_ref()],
                 )

--- a/operator/anarchyrunner.py
+++ b/operator/anarchyrunner.py
@@ -101,6 +101,10 @@ class AnarchyRunner(AnarchyCachedKopfObject):
         """
         return self.pod_template.get('spec', {}).get('serviceAccountName', f"anarchy-runner-{self.name}")
 
+    @property
+    def ignore_pod_management(self):
+        return self.annotations.get(f"{Anarchy.domain}/ignore-pod-management") == "true"
+
     def make_pod_template(self, runner_token=None):
         ret = deepcopy(self.pod_template)
 
@@ -216,6 +220,8 @@ class AnarchyRunner(AnarchyCachedKopfObject):
         await self.manage_pods(logger=logger)
 
     async def manage_pods(self, logger):
+        if self.ignore_pod_management:
+            return
         if not self.pods_preloaded:
             await self.preload_pods()
 

--- a/operator/anarchyrunner.py
+++ b/operator/anarchyrunner.py
@@ -221,6 +221,10 @@ class AnarchyRunner(AnarchyCachedKopfObject):
 
     async def manage_pods(self, logger):
         if self.ignore_pod_management:
+            logger.info(
+                f"Skipping pod management for runner {self.name} "
+                "(ignore-pod-management annotation set)"
+            )
             return
         if not self.pods_preloaded:
             await self.preload_pods()


### PR DESCRIPTION
## Summary

- Add support for the `anarchy.gpte.redhat.com/ignore-pod-management` annotation
  on AnarchyRunner resources, allowing runner pods to be managed externally
- When the annotation is set to `"true"`, the operator skips pod creation,
  pod lifecycle management, and service account provisioning for that runner
- Fix pre-existing bug: use `kubernetes_asyncio.client` instead of `kubernetes.client`
  in service account creation

## Motivation

This enables the use of external runner implementations such as
[babylon-runner](https://github.com/rhpds/babylon-runner), a standalone Go-based
runner that manages its own pods via Helm/HPA instead of relying on the operator's
built-in pod management.

## Usage

```yaml
apiVersion: anarchy.gpte.redhat.com/v1
kind: AnarchyRunner
metadata:
  name: babylon
  annotations:
    anarchy.gpte.redhat.com/ignore-pod-management: "true"
spec:
  minReplicas: 0
  maxReplicas: 0
```