### PR TITLE
chore: standardize SonarQube CI to use shared enterprise pipeline template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,46 +1,14 @@
 ---
+include:
+  - project: enterprise-pipelines/gitlab-ci/includes
+    file: SAST/sonarqube.yml
+
 stages:
   - static-analysis
 
-.static-analysis:
-  stage: static-analysis
-  interruptible: true
-  needs: []
-
-sonarqube-check:
-  extends: .static-analysis
-  image: images.paas.redhat.com/alm/sonar-scanner-alpine:latest
+sonarqube:
   variables:
-    LANG: "en_US.UTF-8"
-    GIT_DEPTH: "0" # Tells git to fetch all the branches of the project, required by the analysis task
-    SONAR_HOST_URL: https://sonarqube.corp.redhat.com
-    SONAR_SCM_PROVIDER: git
-    SONAR_SCANNER_OPTS: "-Xmx512m"
-    SONAR_USER_HOME: /tmp/.sonar
-    KUBERNETES_MEMORY_REQUEST: "512Mi"
-    KUBERNETES_MEMORY_LIMIT: "4Gi"
-    KUBERNETES_EPHEMERAL_STORAGE_REQUEST: "512Mi"
-    KUBERNETES_EPHEMERAL_STORAGE_LIMIT: "1Gi"
-  cache:
-    key: "${CI_JOB_NAME}"
-    paths:
-      - "${SONAR_USER_HOME}/cache"
-  script: 
-    - >
-      set -x; sonar-scanner -Dsonar.python.version="3.9, 3.11, 3.12"
-      ${SONAR_SETTINGS:+-Dproject.settings="$SONAR_SETTINGS"}
-      ${SONAR_QUALITY_GATE_WAIT:+-Dsonar.qualitygate.wait="$SONAR_QUALITY_GATE_WAIT"}
-      ${SONAR_SOURCE_ENCODING:+-Dsonar.sourceEncoding="$SONAR_SOURCE_ENCODING"}
-      ${SONAR_PROJECT_KEY:+-Dsonar.projectKey="$SONAR_PROJECT_KEY"}
-      ${SONAR_PROJECT_NAME:+-Dsonar.projectName="$SONAR_PROJECT_NAME"}
-      ${SONAR_PROJECT_VERSION:+-Dsonar.projectVersion="$SONAR_PROJECT_VERSION"}
-      ${SONAR_SOURCES:+-Dsonar.sources="$SONAR_SOURCES"}
-      ${SONAR_EXCLUSIONS:+-Dsonar.exclusions="$SONAR_EXCLUSIONS"}
-      ${SONAR_SCM_PROVIDER:+-Dsonar.scm.provider="$SONAR_SCM_PROVIDER"}
-      ${CI_MERGE_REQUEST_IID:+-Dsonar.pullrequest.key="$CI_MERGE_REQUEST_IID"}
-      ${CI_MERGE_REQUEST_SOURCE_BRANCH_NAME:+-Dsonar.pullrequest.branch="$CI_MERGE_REQUEST_SOURCE_BRANCH_NAME"}
-      ${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:+-Dsonar.pullrequest.base="$CI_MERGE_REQUEST_TARGET_BRANCH_NAME"}
-  timeout: 15 minutes
-  allow_failure: true
+    SONAR_PROJECT_KEY: "com.redhat.rhpds.redhat-cop.anarchy"
+  needs: []
   tags:
     - itup-alm-x86

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,2 +1,8 @@
 sonar.projectKey=com.redhat.rhpds.redhat-cop.anarchy
 sonar.qualitygate.wait=true
+sonar.python.version=3.12
+
+# Test file patterns
+sonar.test.inclusions=\
+  **/test/unittest-*.py,\
+  **/conftest.py


### PR DESCRIPTION
## Summary

- Replace inline sonarqube job definition with shared template from `enterprise-pipelines/gitlab-ci/includes` (`SAST/sonarqube.yml`)
- Add `sonar.python.version=3.12` and `sonar.test.inclusions` to `sonar-project.properties`
- No exclusions added intentionally — let SonarQube report everything first so we can evaluate what are actual false positives